### PR TITLE
Add server, Docker, frontend crypto & DB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,45 @@
+# =============================================================================
+# Bedroc — Environment Variables
+# Copy this file to .env and fill in all values before running docker compose.
+#
+# NEVER commit .env to git. It is in .gitignore.
+# =============================================================================
+
+# ── Server ────────────────────────────────────────────────────────────────────
+
+# Bind address: WireGuard interface IP of the VPS (10.66.66.1)
+# Change this if your WireGuard IP is different.
+HOST=10.66.66.1
+
+# Internal port Fastify listens on (not exposed publicly; nginx proxies to it)
+PORT=3000
+
+NODE_ENV=production
+
+# ── Database ──────────────────────────────────────────────────────────────────
+# postgres://USER:PASSWORD@HOST:PORT/DATABASE
+# Uses the Docker Compose service name 'postgres' as the host.
+# PASSWORD must match POSTGRES_PASSWORD below.
+DATABASE_URL=postgres://bedroc_app:CHANGE_THIS_DB_PASSWORD@postgres:5432/bedroc
+
+# PostgreSQL superuser password (used by the postgres container on first boot)
+POSTGRES_PASSWORD=CHANGE_THIS_POSTGRES_PASSWORD
+
+# ── Redis ─────────────────────────────────────────────────────────────────────
+REDIS_URL=redis://redis:6379
+
+# ── JWT Secrets ───────────────────────────────────────────────────────────────
+# Generate with: openssl rand -hex 32
+# MUST be at least 32 characters. Use different secrets for access and refresh.
+JWT_ACCESS_SECRET=CHANGE_THIS_GENERATE_WITH_OPENSSL_RAND_HEX_32
+JWT_REFRESH_SECRET=CHANGE_THIS_GENERATE_WITH_OPENSSL_RAND_HEX_32_DIFFERENT
+
+# Token lifetimes (Go duration syntax)
+JWT_ACCESS_EXPIRY=15m
+JWT_REFRESH_EXPIRY=7d
+
+# ── CORS ──────────────────────────────────────────────────────────────────────
+# The origin of the frontend. Must match exactly (no trailing slash).
+# For WireGuard-only access, this is the WireGuard IP:
+CORS_ORIGIN=https://10.66.66.1
+# If you use a domain: CORS_ORIGIN=https://notes.yourdomain.com

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,12 @@ web_modules/
 .env.production.local
 .env.local
 
+# TLS private keys and certificates — never commit to git
+docker/ssl/
+*.pem
+*.key
+*.crt
+
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 .parcel-cache

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1,0 +1,432 @@
+# Bedroc — Self-Hosting Guide
+
+This guide walks you through running your own Bedroc server so only you (and people you invite via VPN) can access your notes. No programming experience required.
+
+> **What you get:** Your notes are encrypted on your device before they leave it. Even the server cannot read them. This guide sets up the server component — a place to store and sync those encrypted blobs.
+
+---
+
+## What you need
+
+- A computer or VPS (Virtual Private Server) to act as the server
+  - Any Linux VPS from DigitalOcean, Hetzner, Linode, Vultr, etc. works — the cheapest tier (~$5/month) is plenty
+  - You can also self-host on a home server or a spare machine
+- **Docker** and **Docker Compose** installed on that machine
+- Basic comfort opening a terminal
+
+Pick your platform below:
+
+---
+
+## Part 1 — Install Docker
+
+### Windows
+
+1. Go to [docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop) and download **Docker Desktop for Windows**
+2. Run the installer. When prompted, keep "Use WSL 2 instead of Hyper-V" checked
+3. After installation, open Docker Desktop and wait for it to say "Engine running" in the bottom-left corner
+4. Open **PowerShell** or **Windows Terminal** and run:
+   ```
+   docker --version
+   docker compose version
+   ```
+   Both should print version numbers. If they do, Docker is ready.
+
+> **Note:** Docker Desktop is fine for testing on your own Windows PC. For a proper server, use a Linux VPS — it's cheaper, always on, and more reliable.
+
+### macOS
+
+1. Go to [docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop) and download **Docker Desktop for Mac**
+   - Choose "Apple Chip" if you have an M1/M2/M3 Mac, or "Intel Chip" otherwise
+2. Open the downloaded `.dmg`, drag Docker to Applications, then launch it
+3. Wait for the whale icon in the menu bar to stop animating
+4. Open **Terminal** and run:
+   ```
+   docker --version
+   docker compose version
+   ```
+   Both should print version numbers.
+
+### Linux (Ubuntu / Debian — recommended for servers)
+
+Run these commands one at a time in your terminal:
+
+```bash
+# Remove old Docker versions if any
+sudo apt-get remove -y docker docker-engine docker.io containerd runc 2>/dev/null || true
+
+# Install prerequisites
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl
+
+# Add Docker's official GPG key and repository
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+  https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# Allow running docker without sudo (log out and back in after this)
+sudo usermod -aG docker $USER
+```
+
+Log out and log back in, then verify:
+```bash
+docker --version
+docker compose version
+```
+
+---
+
+## Part 2 — Set up WireGuard (recommended for private access)
+
+Bedroc's default setup uses [WireGuard](https://www.wireguard.com/) — a modern VPN. This means your notes server is **invisible to the public internet** and only reachable from devices you've personally authorised.
+
+If you just want to test locally or on a LAN, you can skip this and come back to it later. Jump to Part 3 — but note that without WireGuard or a domain with HTTPS, the setup will use plain HTTP.
+
+### Install WireGuard on your server (Linux)
+
+```bash
+sudo apt-get install -y wireguard
+```
+
+### Generate server keys
+
+```bash
+wg genkey | sudo tee /etc/wireguard/server_private.key | wg pubkey | sudo tee /etc/wireguard/server_public.key
+sudo chmod 600 /etc/wireguard/server_private.key
+```
+
+### Create `/etc/wireguard/wg0.conf`
+
+Replace `YOUR_SERVER_PRIVATE_KEY` with the contents of `/etc/wireguard/server_private.key`:
+
+```ini
+[Interface]
+Address = 10.66.66.1/24
+ListenPort = 51820
+PrivateKey = YOUR_SERVER_PRIVATE_KEY
+PostUp = iptables -A FORWARD -i wg0 -j ACCEPT; iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+PostDown = iptables -D FORWARD -i wg0 -j ACCEPT; iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE
+
+# Add a [Peer] block for each device you want to grant access
+# (See "Adding devices" below)
+```
+
+> If your network interface is not `eth0`, replace it with the correct name (`ip link` to check).
+
+### Start WireGuard
+
+```bash
+sudo systemctl enable wg-quick@wg0
+sudo systemctl start wg-quick@wg0
+```
+
+Verify it's running:
+```bash
+sudo wg show
+```
+
+### Open the WireGuard port in your firewall
+
+If using `ufw`:
+```bash
+sudo ufw allow 51820/udp
+```
+
+If your VPS has a cloud firewall (DigitalOcean, Hetzner, etc.), also open UDP port 51820 in the control panel.
+
+### Adding a device (phone, laptop, etc.)
+
+On the **server**, generate a key pair for the new device:
+
+```bash
+wg genkey | tee /tmp/peer_private.key | wg pubkey | tee /tmp/peer_public.key
+```
+
+Add a `[Peer]` block to `/etc/wireguard/wg0.conf`:
+
+```ini
+[Peer]
+# Label (just for your reference — put the device name here)
+# Phone
+PublicKey = PEER_PUBLIC_KEY_HERE
+AllowedIPs = 10.66.66.2/32
+```
+
+Each device needs a unique IP — use `10.66.66.2`, `10.66.66.3`, etc.
+
+Reload WireGuard:
+```bash
+sudo wg syncconf wg0 <(sudo wg-quick strip wg0)
+```
+
+On the **device**, install the WireGuard app:
+- iPhone/iPad: [App Store](https://apps.apple.com/app/wireguard/id1441195209)
+- Android: [Play Store](https://play.google.com/store/apps/details?id=com.wireguard.android)
+- Windows/Mac: [wireguard.com/install](https://www.wireguard.com/install/)
+
+Create a tunnel with this config (replace the placeholders):
+
+```ini
+[Interface]
+PrivateKey = PEER_PRIVATE_KEY_FROM_ABOVE
+Address = 10.66.66.2/32
+DNS = 1.1.1.1
+
+[Peer]
+PublicKey = YOUR_SERVER_PUBLIC_KEY
+Endpoint = YOUR_VPS_PUBLIC_IP:51820
+AllowedIPs = 10.66.66.1/32
+PersistentKeepalive = 25
+```
+
+Once connected to the VPN, your device can reach the server at `10.66.66.1`.
+
+---
+
+## Part 3 — Configure Bedroc
+
+### Get the code
+
+```bash
+git clone https://github.com/MrBiscuitTR/Bedroc.git
+cd Bedroc
+```
+
+Or download and extract the ZIP from GitHub.
+
+### Create the SSL certificate
+
+Even with WireGuard, the app needs HTTPS so the browser allows access to encrypted storage (IndexedDB, Service Workers, etc.). A self-signed certificate is fine — WireGuard peers trust it because they're connecting over an already-encrypted tunnel.
+
+```bash
+mkdir -p docker/ssl
+openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes \
+  -keyout docker/ssl/key.pem \
+  -out docker/ssl/cert.pem \
+  -subj "/CN=bedroc" \
+  -addext "subjectAltName=IP:10.66.66.1"
+```
+
+> If you're using a public domain instead of WireGuard, generate a real certificate with [Let's Encrypt / Certbot](https://certbot.eff.org/) and place `fullchain.pem` → `cert.pem` and `privkey.pem` → `key.pem`.
+
+### Create your `.env` file
+
+```bash
+cp .env.example .env
+```
+
+Open `.env` in a text editor and fill in:
+
+| Variable | What to put |
+|---|---|
+| `POSTGRES_PASSWORD` | Any long random string — this is the database admin password |
+| `DATABASE_URL` | Replace `CHANGE_THIS_DB_PASSWORD` with the same string you put in `POSTGRES_PASSWORD` |
+| `JWT_ACCESS_SECRET` | Run `openssl rand -hex 32` and paste the output |
+| `JWT_REFRESH_SECRET` | Run `openssl rand -hex 32` **again** (must be different from above) |
+| `CORS_ORIGIN` | `https://10.66.66.1` (or your domain: `https://notes.yourdomain.com`) |
+
+Leave everything else as-is unless you know what you're changing.
+
+**How to generate secrets:**
+```bash
+openssl rand -hex 32
+```
+Run this twice to get two different secrets for `JWT_ACCESS_SECRET` and `JWT_REFRESH_SECRET`.
+
+### Start the server
+
+```bash
+docker compose up -d
+```
+
+Docker will download all required images (this takes a few minutes the first time), build the containers, and start everything. To check that all services are healthy:
+
+```bash
+docker compose ps
+```
+
+All services should show `healthy` or `running`. If any show `unhealthy`, check the logs:
+
+```bash
+docker compose logs server
+docker compose logs postgres
+```
+
+---
+
+## Part 4 — Connect from the app
+
+### If using WireGuard
+
+1. Connect your device to the WireGuard VPN
+2. Open the Bedroc app (or visit `https://10.66.66.1` in your browser)
+3. Your browser will warn about the self-signed certificate — this is expected. Click "Advanced" → "Proceed" (Chrome) or "Accept the Risk and Continue" (Firefox)
+4. On the login/register page, the "Server" field should already show `https://10.66.66.1`
+5. Register an account and start using Bedroc
+
+### If using a public domain
+
+1. Point your domain's DNS A record to your VPS IP
+2. Generate a real SSL certificate with Certbot:
+   ```bash
+   sudo apt-get install -y certbot
+   sudo certbot certonly --standalone -d notes.yourdomain.com
+   sudo cp /etc/letsencrypt/live/notes.yourdomain.com/fullchain.pem docker/ssl/cert.pem
+   sudo cp /etc/letsencrypt/live/notes.yourdomain.com/privkey.pem docker/ssl/key.pem
+   ```
+3. In `.env`, change `CORS_ORIGIN=https://notes.yourdomain.com`
+4. Update `docker/nginx/nginx.conf` — change `10.66.66.1` to `0.0.0.0` in the `listen` directives, and set the `server_name` to your domain
+5. Run `docker compose up -d --build`
+6. Open `https://notes.yourdomain.com` in your browser
+
+### From the Bedroc app or website
+
+In the Server field on the login/register page, enter your server address in any format:
+
+| What you type | What Bedroc uses |
+|---|---|
+| `10.66.66.1` | `http://10.66.66.1` |
+| `10.66.66.1:3000` | `http://10.66.66.1:3000` |
+| `notes.yourdomain.com` | `https://notes.yourdomain.com` |
+| `https://notes.yourdomain.com` | `https://notes.yourdomain.com` |
+
+The app saves your server URL so you only need to enter it once.
+
+---
+
+## Managing the server
+
+### Stopping and starting
+
+```bash
+# Stop all services
+docker compose down
+
+# Start again
+docker compose up -d
+
+# Restart a single service
+docker compose restart server
+```
+
+### Viewing logs
+
+```bash
+# All services
+docker compose logs -f
+
+# Just the backend
+docker compose logs -f server
+
+# Last 50 lines
+docker compose logs --tail=50 server
+```
+
+### Updating to a new version
+
+```bash
+git pull
+docker compose up -d --build
+```
+
+Docker rebuilds only what changed. Your data is untouched (it lives in Docker volumes, not in the container).
+
+---
+
+## Backing up your data
+
+All note data is stored in a Docker volume called `bedroc_postgres_data`. To back it up:
+
+```bash
+# Create a backup file (timestamped)
+docker compose exec postgres pg_dump -U postgres bedroc \
+  | gzip > bedroc-backup-$(date +%Y%m%d-%H%M%S).sql.gz
+```
+
+The file can be large if you have many notes, but the data is already encrypted — the backup file is safe to store in the cloud (Dropbox, S3, etc.).
+
+### Restoring a backup
+
+```bash
+# Stop the server first
+docker compose stop server
+
+# Drop and recreate the database
+docker compose exec postgres dropdb -U postgres bedroc
+docker compose exec postgres createdb -U postgres bedroc
+
+# Restore
+gunzip -c bedroc-backup-TIMESTAMP.sql.gz | docker compose exec -T postgres psql -U postgres bedroc
+
+# Start again
+docker compose start server
+```
+
+### Automating backups (Linux — cron)
+
+```bash
+crontab -e
+```
+
+Add this line to back up every day at 3am:
+```
+0 3 * * * cd /path/to/Bedroc && docker compose exec -T postgres pg_dump -U postgres bedroc | gzip > /backups/bedroc-$(date +\%Y\%m\%d).sql.gz
+```
+
+---
+
+## Troubleshooting
+
+### "Cannot reach server" in the app
+
+1. Make sure you're connected to WireGuard (if using VPN setup)
+2. Check that all Docker containers are running: `docker compose ps`
+3. Test the health endpoint from your server: `curl http://localhost:3000/health`
+4. Check the server logs: `docker compose logs server`
+
+### "Certificate error" / browser warning
+
+Expected with a self-signed certificate. Click through the warning once. The connection is still encrypted — the warning just means the certificate wasn't issued by a public certificate authority.
+
+### Forgot to save my server address
+
+The app shows a "Server" toggle on the login page. Click it to see or change the server URL.
+
+### Database won't start
+
+Check logs: `docker compose logs postgres`. The most common cause is a permissions issue on the data volume. Try:
+```bash
+docker compose down -v   # WARNING: this deletes the database
+docker compose up -d
+```
+
+> Only use `-v` if you don't have data you care about, or have a backup.
+
+### Port conflict: something else is already on port 443 or 80
+
+Edit `docker-compose.yml` and change the host port:
+```yaml
+ports:
+  - "10.66.66.1:8443:443"
+  - "10.66.66.1:8080:80"
+```
+Then connect to `https://10.66.66.1:8443` instead.
+
+---
+
+## Security notes
+
+- Your notes are **end-to-end encrypted** — the server stores only ciphertext. The server operator (you) cannot read notes.
+- The JWT secrets in `.env` protect login sessions. Keep them secret and never commit `.env` to git.
+- WireGuard means no attack surface on the public internet — the server is literally unreachable without a valid VPN peer key.
+- Back up your WireGuard private key (`/etc/wireguard/server_private.key`) separately from the server. If you lose it, connected devices can no longer reach the server until you regenerate and redistribute keys.
+- **Password loss = data loss.** The encryption key is derived from your password. There is no account recovery. Use a password manager.

--- a/bedroc/Dockerfile
+++ b/bedroc/Dockerfile
@@ -1,0 +1,43 @@
+# =============================================================================
+# bedroc/Dockerfile — SvelteKit frontend (static adapter → nginx serves it)
+# =============================================================================
+#
+# Multi-stage build:
+#   Stage 1 (builder): `npm run build` produces a static site in /app/build
+#   Stage 2 (runner):  nginx:alpine serves the static files
+#
+# The SvelteKit app must use @sveltejs/adapter-static for this to work.
+# A prerendered SPA (with fallback: 'index.html') handles client-side routing.
+#
+# Note: if you switch to adapter-node for SSR, replace Stage 2 with a Node
+# image similar to server/Dockerfile.
+# =============================================================================
+
+# ── Stage 1: Build ───────────────────────────────────────────────────────────
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# ── Stage 2: Serve with nginx ─────────────────────────────────────────────────
+FROM nginx:1.27-alpine AS runner
+
+# Remove default nginx site
+RUN rm /etc/nginx/conf.d/default.conf
+
+# Copy static build output from builder
+COPY --from=builder /app/build /usr/share/nginx/html
+
+# Simple nginx config: serve static files, SPA fallback to index.html
+# The real reverse-proxy config lives in docker/nginx/nginx.conf
+COPY docker/nginx-static.conf /etc/nginx/conf.d/app.conf
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:8080/ || exit 1

--- a/bedroc/package-lock.json
+++ b/bedroc/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "bedroc",
 			"version": "0.0.1",
 			"devDependencies": {
-				"@sveltejs/adapter-auto": "^7.0.0",
+				"@sveltejs/adapter-static": "^3.0.8",
 				"@sveltejs/kit": "^2.50.2",
 				"@sveltejs/vite-plugin-svelte": "^6.2.4",
 				"@tailwindcss/vite": "^4.2.1",
@@ -885,10 +885,10 @@
 				"acorn": "^8.9.0"
 			}
 		},
-		"node_modules/@sveltejs/adapter-auto": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-7.0.1.tgz",
-			"integrity": "sha512-dvuPm1E7M9NI/+canIQ6KKQDU2AkEefEZ2Dp7cY6uKoPq9Z/PhOXABe526UdW2mN986gjVkuSLkOYIBnS/M2LQ==",
+		"node_modules/@sveltejs/adapter-static": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-3.0.10.tgz",
+			"integrity": "sha512-7D9lYFWJmB7zxZyTE/qxjksvMqzMuYrrsyh1f4AlZqeZeACPRySjbC3aFiY55wb1tWUaKOQG9PVbm74JcN2Iew==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {

--- a/bedroc/package.json
+++ b/bedroc/package.json
@@ -12,7 +12,7 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-auto": "^7.0.0",
+		"@sveltejs/adapter-static": "^3.0.8",
 		"@sveltejs/kit": "^2.50.2",
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
 		"@tailwindcss/vite": "^4.2.1",

--- a/bedroc/src/lib/crypto/encrypt.ts
+++ b/bedroc/src/lib/crypto/encrypt.ts
@@ -1,0 +1,143 @@
+/**
+ * lib/crypto/encrypt.ts — AES-256-GCM note encryption/decryption.
+ *
+ * Each note field (title, body) is encrypted independently with its own
+ * random 96-bit IV. Ciphertexts are stored as JSON:
+ *   { iv: "<base64>", ct: "<base64>" }
+ *
+ * The same DEK (Data Encryption Key) encrypts all notes for a user.
+ * The DEK lives in memory only — see keys.ts for derivation details.
+ *
+ * Why per-field IVs?
+ *   - Prevents the same (key, IV) pair from ever being reused.
+ *   - AES-GCM is catastrophically broken if (key, IV) is reused.
+ *   - Generating a fresh random IV on every encrypt call is the
+ *     standard mitigation — 96 bits gives a negligible collision
+ *     probability even with billions of notes.
+ *
+ * Why separate encryption of title vs body?
+ *   - Allows the server to return note metadata (title only) in list
+ *     views without sending the full body — but since the server is
+ *     a dumb blob store, this is mainly for future optionality.
+ *   - Also means a title edit doesn't change the body ciphertext,
+ *     reducing sync diff size.
+ */
+
+import { toBase64, fromBase64, randomBytes } from './keys.js';
+
+/** Wire format stored in the database (and IndexedDB). */
+export interface EncryptedField {
+  iv: string;  // base64-encoded 12-byte IV
+  ct: string;  // base64-encoded AES-GCM ciphertext + 16-byte auth tag
+}
+
+/**
+ * Encrypt a plaintext string with the given DEK.
+ *
+ * @param plaintext  — UTF-8 string (note title or body)
+ * @param dek        — CryptoKey (AES-256-GCM, from keys.ts)
+ * @returns          — EncryptedField JSON-serialisable object
+ */
+export async function encryptField(
+  plaintext: string,
+  dek: CryptoKey
+): Promise<EncryptedField> {
+  const iv = randomBytes(12); // 96-bit IV
+  const encoded = new TextEncoder().encode(plaintext);
+
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    dek,
+    encoded
+  );
+
+  return {
+    iv: toBase64(iv),
+    ct: toBase64(new Uint8Array(ciphertext)),
+  };
+}
+
+/**
+ * Decrypt an EncryptedField with the given DEK.
+ *
+ * @param field  — { iv, ct } object from database / IndexedDB
+ * @param dek    — CryptoKey (AES-256-GCM)
+ * @returns      — plaintext UTF-8 string
+ * @throws       — if DEK is wrong or ciphertext is tampered (GCM auth fails)
+ */
+export async function decryptField(
+  field: EncryptedField,
+  dek: CryptoKey
+): Promise<string> {
+  const iv = fromBase64(field.iv);
+  const ct = fromBase64(field.ct);
+
+  const plaintext = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv },
+    dek,
+    ct
+  );
+
+  return new TextDecoder().decode(plaintext);
+}
+
+/**
+ * Serialise an EncryptedField to a JSON string for storage.
+ * The server stores this string in `encrypted_title` / `encrypted_body`.
+ */
+export function serialiseField(field: EncryptedField): string {
+  return JSON.stringify(field);
+}
+
+/**
+ * Parse a JSON string back into an EncryptedField.
+ * Returns null if the string is empty or malformed (e.g. new note with no content).
+ */
+export function parseField(json: string): EncryptedField | null {
+  if (!json || json === '{}') return null;
+  try {
+    return JSON.parse(json) as EncryptedField;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Convenience: encrypt title and body together.
+ * Returns serialised JSON strings ready to send to the server.
+ */
+export async function encryptNote(
+  title: string,
+  body: string,
+  dek: CryptoKey
+): Promise<{ encryptedTitle: string; encryptedBody: string }> {
+  const [titleField, bodyField] = await Promise.all([
+    encryptField(title, dek),
+    encryptField(body, dek),
+  ]);
+  return {
+    encryptedTitle: serialiseField(titleField),
+    encryptedBody: serialiseField(bodyField),
+  };
+}
+
+/**
+ * Convenience: decrypt title and body together.
+ * Accepts the raw JSON strings stored on the server.
+ * Returns empty strings for fields that are missing or not yet written.
+ */
+export async function decryptNote(
+  encryptedTitle: string,
+  encryptedBody: string,
+  dek: CryptoKey
+): Promise<{ title: string; body: string }> {
+  const titleField = parseField(encryptedTitle);
+  const bodyField = parseField(encryptedBody);
+
+  const [title, body] = await Promise.all([
+    titleField ? decryptField(titleField, dek) : Promise.resolve(''),
+    bodyField ? decryptField(bodyField, dek) : Promise.resolve(''),
+  ]);
+
+  return { title, body };
+}

--- a/bedroc/src/lib/crypto/keys.ts
+++ b/bedroc/src/lib/crypto/keys.ts
@@ -1,0 +1,189 @@
+/**
+ * lib/crypto/keys.ts — Key derivation and DEK management.
+ *
+ * Two-layer key architecture:
+ *
+ *   Password
+ *     └─ PBKDF2(password, dekSalt, 600_000 iterations, SHA-256) ─→ Master Key (AES-256)
+ *           └─ AES-256-GCM.decrypt(encryptedDek) ─→ DEK (Data Encryption Key)
+ *                 └─ AES-256-GCM.encrypt(noteTitle | noteBody) ─→ ciphertext
+ *
+ * The server stores:
+ *   - `encrypted_dek`  — { iv: base64, ct: base64 } JSON string
+ *   - `dek_salt`       — hex string (32 bytes)
+ *
+ * The server NEVER sees the plaintext DEK or Master Key.
+ * The DEK lives in memory only (never written to disk/localStorage).
+ *
+ * All crypto is via the browser-native WebCrypto API — no external libraries.
+ */
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Encode a Uint8Array to a base64 string. */
+export function toBase64(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes));
+}
+
+/** Decode a base64 string to a Uint8Array. */
+export function fromBase64(b64: string): Uint8Array {
+  return Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+}
+
+/** Encode a Uint8Array to a lowercase hex string. */
+export function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes).map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/** Decode a hex string to a Uint8Array. */
+export function fromHex(hex: string): Uint8Array {
+  const result = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    result[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return result;
+}
+
+/** Encode a string as UTF-8 bytes. */
+export function encode(str: string): Uint8Array {
+  return new TextEncoder().encode(str);
+}
+
+/** Decode UTF-8 bytes to a string. */
+export function decode(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
+}
+
+/** Cryptographically random bytes. */
+export function randomBytes(n: number): Uint8Array {
+  return crypto.getRandomValues(new Uint8Array(n));
+}
+
+// ---------------------------------------------------------------------------
+// Key import
+// ---------------------------------------------------------------------------
+
+/**
+ * Import raw bytes as a CryptoKey for AES-256-GCM.
+ * @param keyBytes  — 32 raw bytes
+ * @param usage     — 'encrypt' | 'decrypt' | both
+ */
+async function importAesKey(
+  keyBytes: Uint8Array,
+  usage: KeyUsage[]
+): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'raw',
+    keyBytes,
+    { name: 'AES-GCM', length: 256 },
+    false, // not extractable — key stays in secure memory
+    usage
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Master Key derivation via PBKDF2
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive a Master Key from the user's password and a salt using PBKDF2.
+ *
+ * @param password  — plaintext password (UTF-8 string)
+ * @param dekSalt   — 32-byte random salt (stored on server as hex)
+ * @returns         — AES-256-GCM CryptoKey for wrapping/unwrapping the DEK
+ */
+export async function deriveMasterKey(
+  password: string,
+  dekSalt: Uint8Array
+): Promise<CryptoKey> {
+  // Import password as raw key material for PBKDF2
+  const passwordKey = await crypto.subtle.importKey(
+    'raw',
+    encode(password),
+    'PBKDF2',
+    false,
+    ['deriveKey']
+  );
+
+  // Derive AES-256-GCM key via PBKDF2
+  // 600,000 iterations is the OWASP 2023 minimum for PBKDF2-SHA-256.
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt: dekSalt,
+      iterations: 600_000,
+      hash: 'SHA-256',
+    },
+    passwordKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+}
+
+// ---------------------------------------------------------------------------
+// DEK (Data Encryption Key) generation, wrapping, unwrapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a new random DEK (Data Encryption Key).
+ * Called once during user registration. The DEK is wrapped with the Master Key
+ * and stored on the server; it never leaves the client in plaintext.
+ *
+ * @returns { dek, dekRaw } — CryptoKey for use + raw bytes for wrapping
+ */
+export async function generateDek(): Promise<{ dek: CryptoKey; dekRaw: Uint8Array }> {
+  const dekRaw = randomBytes(32); // 256-bit random key
+  const dek = await importAesKey(dekRaw, ['encrypt', 'decrypt']);
+  return { dek, dekRaw };
+}
+
+/**
+ * Wrap (encrypt) the DEK with the Master Key.
+ * The result is the `encrypted_dek` value stored on the server.
+ *
+ * @param dekRaw      — 32 raw DEK bytes
+ * @param masterKey   — CryptoKey derived from password via deriveMasterKey()
+ * @returns           — JSON string { iv: base64, ct: base64 }
+ */
+export async function wrapDek(dekRaw: Uint8Array, masterKey: CryptoKey): Promise<string> {
+  const iv = randomBytes(12); // 96-bit IV for AES-GCM
+  const ct = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    masterKey,
+    dekRaw
+  );
+  return JSON.stringify({
+    iv: toBase64(iv),
+    ct: toBase64(new Uint8Array(ct)),
+  });
+}
+
+/**
+ * Unwrap (decrypt) the DEK using the Master Key.
+ * Called after a successful login to load the DEK into memory.
+ *
+ * @param encryptedDek  — JSON string { iv: base64, ct: base64 } from server
+ * @param masterKey     — CryptoKey derived from password via deriveMasterKey()
+ * @returns             — CryptoKey for encrypting/decrypting notes
+ * @throws              — if password is wrong (decryption will fail)
+ */
+export async function unwrapDek(encryptedDek: string, masterKey: CryptoKey): Promise<CryptoKey> {
+  const { iv, ct } = JSON.parse(encryptedDek) as { iv: string; ct: string };
+  const dekRaw = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: fromBase64(iv) },
+    masterKey,
+    fromBase64(ct)
+  );
+  return importAesKey(new Uint8Array(dekRaw), ['encrypt', 'decrypt']);
+}
+
+/**
+ * Export the DEK as raw bytes. Used for SRP session key re-derivation.
+ * The key is non-extractable in normal use; this is only for key migration.
+ * (Not exposed in the main API — reserved for future use.)
+ */
+// We intentionally do NOT export dekRaw from CryptoKey — non-extractable is
+// the correct setting. Raw bytes are only used at wrap time in generateDek().

--- a/bedroc/src/lib/crypto/srp.ts
+++ b/bedroc/src/lib/crypto/srp.ts
@@ -1,0 +1,254 @@
+/**
+ * lib/crypto/srp.ts — SRP-6a client implementation.
+ *
+ * Secure Remote Password (RFC 2945 / SRP-6a) lets the client prove knowledge
+ * of the password without ever sending it to the server. The server stores
+ * only a verifier derived from the password, making server compromise useless
+ * for recovering plaintext passwords.
+ *
+ * This implementation uses the same 3072-bit MODP group (RFC 3526) as the
+ * server. All BigInt math is pure browser JS — no external libraries.
+ *
+ * Registration flow:
+ *   1. Client generates salt (random 32 bytes)
+ *   2. x  = H(salt | H(username | ':' | password))
+ *   3. v  = g^x mod N  ← sent to server along with username and salt
+ *   4. Server stores (username, salt, verifier=v)
+ *
+ * Login flow:
+ *   1. Client → Server: username
+ *   2. Server → Client: salt, B (server ephemeral public key)
+ *   3. Client computes:
+ *      a  = random 256-bit integer
+ *      A  = g^a mod N
+ *      u  = H(PAD(A) | PAD(B))
+ *      x  = H(salt | H(username | ':' | password))
+ *      S  = (B - k*g^x)^(a + u*x) mod N
+ *      K  = H(S)               (session key)
+ *      M1 = H(H(N) XOR H(g) | H(username) | salt | A | B | K)
+ *   4. Client → Server: A, M1
+ *   5. Server verifies M1; if valid, responds with M2 = H(A | M1 | K)
+ *   6. Client verifies M2 (proves server also knows the password)
+ */
+
+import { toBase64, fromBase64, toHex, fromHex, randomBytes } from './keys.js';
+
+// ---------------------------------------------------------------------------
+// 3072-bit MODP group (RFC 3526, Section 2)
+// Same prime used on the server — must match exactly.
+// ---------------------------------------------------------------------------
+const N_HEX =
+  'FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD1' +
+  '29024E088A67CC74020BBEA63B139B22514A08798E3404DD' +
+  'EF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245' +
+  'E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7ED' +
+  'EE386BFB5A899FA5AE9F24117C4B1FE649286651ECE45B3D' +
+  'C2007CB8A163BF0598DA48361C55D39A69163FA8FD24CF5F' +
+  '83655D23DCA3AD961C62F356208552BB9ED529077096966D' +
+  '670C354E4ABC9804F1746C08CA18217C32905E462E36CE3B' +
+  'E39E772C180E86039B2783A2EC07A28FB5C55DF06F4C52C9' +
+  'DE2BCBF6955817183995497CEA956AE515D2261898FA0510' +
+  '15728E5A8AAAC42DAD33170D04507A33A85521ABDF1CBA64' +
+  'ECFB850458DBEF0A8AEA71575D060C7DB3970F85A6E1E4C7' +
+  'ABF5AE8CDB0933D71E8C94E04A25619DCEE3D2261AD2EE6B' +
+  'F12FFA06D98A0864D87602733EC86A64521F2B18177B200C' +
+  'BBE117577A615D6C770988C0BAD946E208E24FA074E5AB31' +
+  '43DB5BFCE0FD108E4B82D120A93AD2CAFFFFFFFFFFFFFFFF';
+
+const N = BigInt('0x' + N_HEX);
+const g = 2n;
+const PAD_LEN = N_HEX.length / 2; // byte length of N for left-padding
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** SHA-256 hash of arbitrary bytes. Returns raw Uint8Array. */
+async function sha256(data: Uint8Array): Promise<Uint8Array> {
+  return new Uint8Array(await crypto.subtle.digest('SHA-256', data));
+}
+
+/** Concat any number of Uint8Arrays into one. */
+function concat(...arrays: Uint8Array[]): Uint8Array {
+  const total = arrays.reduce((n, a) => n + a.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const a of arrays) {
+    out.set(a, offset);
+    offset += a.length;
+  }
+  return out;
+}
+
+/** Left-pad a BigInt's byte representation to PAD_LEN bytes. */
+function pad(n: bigint): Uint8Array {
+  const hex = n.toString(16).padStart(PAD_LEN * 2, '0');
+  return fromHex(hex);
+}
+
+/** Fast modular exponentiation: base^exp mod mod. */
+function modpow(base: bigint, exp: bigint, mod: bigint): bigint {
+  let result = 1n;
+  base = base % mod;
+  while (exp > 0n) {
+    if (exp % 2n === 1n) result = (result * base) % mod;
+    exp = exp >> 1n;
+    base = (base * base) % mod;
+  }
+  return result;
+}
+
+/** Compute the SRP multiplier k = H(N | PAD(g)). */
+async function srpK(): Promise<bigint> {
+  const h = await sha256(concat(pad(N), pad(g)));
+  return BigInt('0x' + toHex(h));
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate SRP registration material for a new account.
+ *
+ * @param username  — plaintext username
+ * @param password  — plaintext password (never sent to server)
+ * @returns {
+ *   salt       — hex-encoded 32-byte random salt (send to server)
+ *   verifier   — hex-encoded SRP verifier v = g^x mod N (send to server)
+ * }
+ */
+export async function srpRegister(
+  username: string,
+  password: string
+): Promise<{ salt: string; verifier: string }> {
+  const saltBytes = randomBytes(32);
+  const salt = toHex(saltBytes);
+
+  // x = H(salt | H(username:password))
+  const identityHash = await sha256(new TextEncoder().encode(`${username}:${password}`));
+  const x = BigInt(
+    '0x' +
+      toHex(await sha256(concat(saltBytes, identityHash)))
+  );
+
+  // v = g^x mod N
+  const v = modpow(g, x, N);
+  const verifier = toHex(pad(v));
+
+  return { salt, verifier };
+}
+
+// ---------------------------------------------------------------------------
+// Login
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the client's ephemeral public key A = g^a mod N.
+ * Called at the start of login; A is sent to the server.
+ *
+ * @returns { a (private, keep secret), A (public, send to server as hex) }
+ */
+export function srpClientEphemeral(): { a: bigint; A: string } {
+  // 256 bits of entropy for the private ephemeral
+  const aBytes = randomBytes(32);
+  const a = BigInt('0x' + toHex(aBytes));
+  const A = modpow(g, a, N);
+  return { a, A: toHex(pad(A)) };
+}
+
+/**
+ * Compute client proof M1 and the session key K.
+ *
+ * Called after receiving (salt, B) from the server.
+ *
+ * @param username  — plaintext username
+ * @param password  — plaintext password
+ * @param saltHex   — hex-encoded salt from server
+ * @param AHex      — hex-encoded client public key (from srpClientEphemeral)
+ * @param BHex      — hex-encoded server public key from server
+ * @param a         — private client ephemeral BigInt (from srpClientEphemeral)
+ * @returns {
+ *   M1        — hex-encoded client proof (send to server)
+ *   sessionKey — Uint8Array — shared session key K (for optional use)
+ * }
+ * @throws if B is zero mod N (abort: invalid server value)
+ */
+export async function srpClientProof(params: {
+  username: string;
+  password: string;
+  saltHex: string;
+  AHex: string;
+  BHex: string;
+  a: bigint;
+}): Promise<{ M1: string; sessionKey: Uint8Array }> {
+  const { username, password, saltHex, AHex, BHex, a } = params;
+
+  const saltBytes = fromHex(saltHex);
+  const A = BigInt('0x' + AHex);
+  const B = BigInt('0x' + BHex);
+
+  // Validate B != 0 mod N (SRP abort condition)
+  if (B % N === 0n) throw new Error('SRP: invalid server public key B');
+
+  const k = await srpK();
+
+  // u = H(PAD(A) | PAD(B))
+  const u = BigInt('0x' + toHex(await sha256(concat(pad(A), pad(B)))));
+  if (u === 0n) throw new Error('SRP: u = 0, aborting');
+
+  // x = H(salt | H(username:password))
+  const identityHash = await sha256(new TextEncoder().encode(`${username}:${password}`));
+  const xHash = await sha256(concat(saltBytes, identityHash));
+  const x = BigInt('0x' + toHex(xHash));
+
+  // Client session premaster: S = (B - k*g^x)^(a + u*x) mod N
+  const kgx = (k * modpow(g, x, N)) % N;
+  // Ensure positive: add N if negative
+  const base = ((B - kgx) % N + N) % N;
+  const exp = (a + u * x) % (N - 1n); // a + u*x mod (N-1) per SRP-6a
+  const S = modpow(base, exp, N);
+
+  // Session key K = H(S)
+  const sessionKey = await sha256(pad(S));
+
+  // M1 = H( H(N) XOR H(g) | H(username) | salt | A | B | K )
+  const HN = await sha256(pad(N));
+  const Hg = await sha256(pad(g));
+  const HNxorHg = HN.map((b, i) => b ^ Hg[i]);
+  const Husername = await sha256(new TextEncoder().encode(username));
+
+  const M1 = await sha256(
+    concat(HNxorHg, Husername, saltBytes, pad(A), pad(B), sessionKey)
+  );
+
+  return { M1: toHex(M1), sessionKey };
+}
+
+/**
+ * Verify the server's proof M2.
+ * If this fails, the server does not know the correct password.
+ *
+ * @param AHex        — hex client public key
+ * @param M1Hex       — hex client proof (same M1 sent to server)
+ * @param sessionKey  — Uint8Array session key K
+ * @param serverM2    — hex M2 received from server
+ * @throws if server M2 does not match expected
+ */
+export async function srpVerifyServer(
+  AHex: string,
+  M1Hex: string,
+  sessionKey: Uint8Array,
+  serverM2: string
+): Promise<void> {
+  const A = fromHex(AHex);
+  const M1 = fromHex(M1Hex);
+
+  // Expected M2 = H(A | M1 | K)
+  const expectedM2 = await sha256(concat(A, M1, sessionKey));
+  const expectedHex = toHex(expectedM2);
+
+  if (expectedHex !== serverM2) {
+    throw new Error('SRP: server proof verification failed — possible MITM or wrong password');
+  }
+}

--- a/bedroc/src/lib/db/indexeddb.ts
+++ b/bedroc/src/lib/db/indexeddb.ts
@@ -1,0 +1,345 @@
+/**
+ * lib/db/indexeddb.ts — IndexedDB offline-first storage layer.
+ *
+ * Stores all user data locally so the app works fully offline.
+ * The server is a sync target, not the primary store.
+ *
+ * Database: "bedroc" (version 1)
+ * Object stores:
+ *   notes      — NoteLocal records (decrypted title/body stored in plain text)
+ *   topics     — TopicLocal records
+ *   folders    — FolderLocal records
+ *   syncQueue  — pending writes to be flushed to server (encrypted)
+ *   keyMaterial — encrypted DEK + derivation params (one record per account)
+ *
+ * Design decisions:
+ *   - notes are stored DECRYPTED in IndexedDB (client-local only).
+ *     IndexedDB is not accessible from other origins and is sandboxed.
+ *     Storing decrypted content enables offline text search without re-decrypting.
+ *   - syncQueue holds the server payload (encrypted ciphertext) to avoid
+ *     needing the DEK to be available when the sync flush actually runs.
+ *   - keyMaterial is NOT the plaintext DEK — it's the encrypted_dek blob from
+ *     the server plus the dekSalt needed to re-derive the master key from password.
+ *     This allows the app to restore the DEK from password on next open without
+ *     fetching from the server while offline.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface NoteLocal {
+  id: string;
+  userId: string;
+  topicId: string | null;
+  title: string;        // plaintext (decrypted client-side)
+  body: string;         // plaintext
+  customOrder: number;
+  clientUpdatedAt: number; // Unix timestamp ms
+  serverUpdatedAt: number; // 0 if not yet synced
+  isDeleted: boolean;
+  version: number;
+  synced: boolean;      // true = server has this version
+}
+
+export interface TopicLocal {
+  id: string;
+  userId: string;
+  name: string;
+  color: string;
+  folderId: string | null;
+  sortOrder: number;
+  synced: boolean;
+}
+
+export interface FolderLocal {
+  id: string;
+  userId: string;
+  name: string;
+  parentId: string | null;
+  sortOrder: number;
+  collapsed: boolean;
+  synced: boolean;
+}
+
+/** A pending write queued for server sync. */
+export interface SyncQueueItem {
+  id: string;             // same as the note/topic/folder id
+  type: 'note' | 'topic' | 'folder';
+  action: 'upsert' | 'delete';
+  /** Encrypted server payload — ready to PUT/DELETE via API. */
+  payload: unknown;
+  createdAt: number;
+  retries: number;
+}
+
+/** Stored key material for restoring the DEK after page reload. */
+export interface KeyMaterialRecord {
+  id: 'current';          // singleton record
+  username: string;
+  serverUrl: string;
+  encryptedDek: string;   // JSON blob from server (iv + ciphertext)
+  dekSaltHex: string;     // hex 32-byte salt for PBKDF2
+}
+
+// ---------------------------------------------------------------------------
+// DB singleton
+// ---------------------------------------------------------------------------
+
+let db: IDBDatabase | null = null;
+const DB_NAME = 'bedroc';
+const DB_VERSION = 1;
+
+/** Open (or return cached) IndexedDB instance. */
+export function openDb(): Promise<IDBDatabase> {
+  if (db) return Promise.resolve(db);
+
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+
+    req.onupgradeneeded = (event) => {
+      const d = (event.target as IDBOpenDBRequest).result;
+
+      // notes
+      const notes = d.createObjectStore('notes', { keyPath: 'id' });
+      notes.createIndex('by_user', 'userId');
+      notes.createIndex('by_user_topic', ['userId', 'topicId']);
+      notes.createIndex('by_user_order', ['userId', 'customOrder']);
+      notes.createIndex('by_updated', ['userId', 'clientUpdatedAt']);
+      notes.createIndex('unsynced', ['userId', 'synced']);
+
+      // topics
+      const topics = d.createObjectStore('topics', { keyPath: 'id' });
+      topics.createIndex('by_user', 'userId');
+
+      // folders
+      const folders = d.createObjectStore('folders', { keyPath: 'id' });
+      folders.createIndex('by_user', 'userId');
+
+      // syncQueue
+      const queue = d.createObjectStore('syncQueue', { keyPath: 'id' });
+      queue.createIndex('by_type', 'type');
+      queue.createIndex('by_created', 'createdAt');
+
+      // keyMaterial
+      d.createObjectStore('keyMaterial', { keyPath: 'id' });
+    };
+
+    req.onsuccess = (event) => {
+      db = (event.target as IDBOpenDBRequest).result;
+      resolve(db);
+    };
+
+    req.onerror = () => reject(req.error);
+    req.onblocked = () => reject(new Error('IndexedDB upgrade blocked by another tab'));
+  });
+}
+
+/** Close the DB connection (call on logout to release lock). */
+export function closeDb(): void {
+  db?.close();
+  db = null;
+}
+
+// ---------------------------------------------------------------------------
+// Generic helpers
+// ---------------------------------------------------------------------------
+
+function idbRequest<T>(req: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function getStore(
+  storeName: string,
+  mode: IDBTransactionMode
+): Promise<IDBObjectStore> {
+  const d = await openDb();
+  return d.transaction(storeName, mode).objectStore(storeName);
+}
+
+// ---------------------------------------------------------------------------
+// Notes
+// ---------------------------------------------------------------------------
+
+export async function saveNote(note: NoteLocal): Promise<void> {
+  const store = await getStore('notes', 'readwrite');
+  await idbRequest(store.put(note));
+}
+
+export async function getNoteById(id: string): Promise<NoteLocal | undefined> {
+  const store = await getStore('notes', 'readonly');
+  return idbRequest(store.get(id));
+}
+
+export async function getNotesByUser(userId: string): Promise<NoteLocal[]> {
+  const store = await getStore('notes', 'readonly');
+  const idx = store.index('by_user');
+  const notes = await idbRequest<NoteLocal[]>(idx.getAll(userId));
+  return notes.filter((n) => !n.isDeleted);
+}
+
+export async function getNotesByTopic(
+  userId: string,
+  topicId: string | null
+): Promise<NoteLocal[]> {
+  const store = await getStore('notes', 'readonly');
+  const idx = store.index('by_user_topic');
+  const notes = await idbRequest<NoteLocal[]>(idx.getAll([userId, topicId]));
+  return notes.filter((n) => !n.isDeleted);
+}
+
+export async function deleteNoteLocal(id: string): Promise<void> {
+  const store = await getStore('notes', 'readwrite');
+  await idbRequest(store.delete(id));
+}
+
+export async function markNoteDeleted(id: string): Promise<void> {
+  const note = await getNoteById(id);
+  if (!note) return;
+  const store = await getStore('notes', 'readwrite');
+  await idbRequest(store.put({ ...note, isDeleted: true, synced: false }));
+}
+
+// ---------------------------------------------------------------------------
+// Topics
+// ---------------------------------------------------------------------------
+
+export async function saveTopic(topic: TopicLocal): Promise<void> {
+  const store = await getStore('topics', 'readwrite');
+  await idbRequest(store.put(topic));
+}
+
+export async function getTopicsByUser(userId: string): Promise<TopicLocal[]> {
+  const store = await getStore('topics', 'readonly');
+  const idx = store.index('by_user');
+  return idbRequest<TopicLocal[]>(idx.getAll(userId));
+}
+
+export async function deleteTopic(id: string): Promise<void> {
+  const store = await getStore('topics', 'readwrite');
+  await idbRequest(store.delete(id));
+}
+
+// ---------------------------------------------------------------------------
+// Folders
+// ---------------------------------------------------------------------------
+
+export async function saveFolder(folder: FolderLocal): Promise<void> {
+  const store = await getStore('folders', 'readwrite');
+  await idbRequest(store.put(folder));
+}
+
+export async function getFoldersByUser(userId: string): Promise<FolderLocal[]> {
+  const store = await getStore('folders', 'readonly');
+  const idx = store.index('by_user');
+  return idbRequest<FolderLocal[]>(idx.getAll(userId));
+}
+
+export async function deleteFolder(id: string): Promise<void> {
+  const store = await getStore('folders', 'readwrite');
+  await idbRequest(store.delete(id));
+}
+
+// ---------------------------------------------------------------------------
+// Sync queue
+// ---------------------------------------------------------------------------
+
+export async function enqueueSyncItem(item: SyncQueueItem): Promise<void> {
+  const store = await getStore('syncQueue', 'readwrite');
+  await idbRequest(store.put(item));
+}
+
+export async function dequeueSyncItem(id: string): Promise<void> {
+  const store = await getStore('syncQueue', 'readwrite');
+  await idbRequest(store.delete(id));
+}
+
+export async function getAllSyncQueue(): Promise<SyncQueueItem[]> {
+  const store = await getStore('syncQueue', 'readonly');
+  return idbRequest<SyncQueueItem[]>(store.getAll());
+}
+
+export async function incrementRetry(id: string): Promise<void> {
+  const store = await getStore('syncQueue', 'readwrite');
+  const item = await idbRequest<SyncQueueItem>(store.get(id));
+  if (item) await idbRequest(store.put({ ...item, retries: item.retries + 1 }));
+}
+
+// ---------------------------------------------------------------------------
+// Key material
+// ---------------------------------------------------------------------------
+
+export async function saveKeyMaterial(record: KeyMaterialRecord): Promise<void> {
+  const store = await getStore('keyMaterial', 'readwrite');
+  await idbRequest(store.put(record));
+}
+
+export async function loadKeyMaterial(): Promise<KeyMaterialRecord | undefined> {
+  const store = await getStore('keyMaterial', 'readonly');
+  return idbRequest(store.get('current'));
+}
+
+export async function clearKeyMaterial(): Promise<void> {
+  const store = await getStore('keyMaterial', 'readwrite');
+  await idbRequest(store.delete('current'));
+}
+
+// ---------------------------------------------------------------------------
+// Full wipe (logout / account delete)
+// ---------------------------------------------------------------------------
+
+/** Clear all data for a user from every object store. */
+export async function wipeLocalData(userId: string): Promise<void> {
+  const d = await openDb();
+  const tx = d.transaction(['notes', 'topics', 'folders', 'syncQueue', 'keyMaterial'], 'readwrite');
+
+  // Delete notes
+  const noteIdx = tx.objectStore('notes').index('by_user');
+  await new Promise<void>((resolve, reject) => {
+    const req = noteIdx.openCursor(userId);
+    req.onsuccess = () => {
+      const cursor = req.result;
+      if (cursor) { cursor.delete(); cursor.continue(); }
+      else resolve();
+    };
+    req.onerror = () => reject(req.error);
+  });
+
+  // Delete topics
+  const topicIdx = tx.objectStore('topics').index('by_user');
+  await new Promise<void>((resolve, reject) => {
+    const req = topicIdx.openCursor(userId);
+    req.onsuccess = () => {
+      const cursor = req.result;
+      if (cursor) { cursor.delete(); cursor.continue(); }
+      else resolve();
+    };
+    req.onerror = () => reject(req.error);
+  });
+
+  // Delete folders
+  const folderIdx = tx.objectStore('folders').index('by_user');
+  await new Promise<void>((resolve, reject) => {
+    const req = folderIdx.openCursor(userId);
+    req.onsuccess = () => {
+      const cursor = req.result;
+      if (cursor) { cursor.delete(); cursor.continue(); }
+      else resolve();
+    };
+    req.onerror = () => reject(req.error);
+  });
+
+  // Clear entire sync queue and key material
+  tx.objectStore('syncQueue').clear();
+  tx.objectStore('keyMaterial').clear();
+
+  await new Promise<void>((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+
+  closeDb();
+}

--- a/bedroc/src/lib/stores/auth.svelte.ts
+++ b/bedroc/src/lib/stores/auth.svelte.ts
@@ -1,0 +1,560 @@
+/**
+ * lib/stores/auth.svelte.ts — Authentication state and API client.
+ *
+ * Manages:
+ *   - Server URL with saved-server list (persisted in localStorage)
+ *   - Access token (in memory only — never written to localStorage)
+ *   - DEK (Data Encryption Key) — in memory only, never persisted
+ *   - Login flow (SRP-6a two-step)
+ *   - Register flow (SRP verifier generation + DEK creation)
+ *   - Logout (clears memory state + wipes IndexedDB)
+ *   - Token refresh (called automatically on 401)
+ *   - apiFetch() — authenticated fetch with auto-refresh
+ *
+ * Security properties:
+ *   - Access token in memory → cleared on page unload / logout
+ *   - DEK in memory → derived from password on each login; never written to disk
+ *   - Key material (encryptedDek + dekSalt) saved to IndexedDB → allows
+ *     restoring the DEK from password without a server round-trip when offline
+ *   - Refresh token is httpOnly cookie → not readable from JS
+ *   - Server URL saved to localStorage (not sensitive)
+ */
+
+import { goto } from '$app/navigation';
+import {
+  deriveMasterKey,
+  generateDek,
+  wrapDek,
+  unwrapDek,
+  randomBytes,
+  toHex,
+  fromHex,
+} from '$lib/crypto/keys.js';
+import {
+  srpRegister,
+  srpClientEphemeral,
+  srpClientProof,
+  srpVerifyServer,
+} from '$lib/crypto/srp.js';
+import {
+  saveKeyMaterial,
+  loadKeyMaterial,
+  clearKeyMaterial,
+  wipeLocalData,
+} from '$lib/db/indexeddb.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_SERVER = 'https://api.bedroc.app';
+const LS_SERVERS_KEY = 'bedroc_servers';      // saved server list
+const LS_LAST_SERVER_KEY = 'bedroc_last_srv'; // most recently used server URL
+const REQUEST_TIMEOUT_MS = 12_000;            // 12s before treating as unreachable
+
+/** Fetch with an AbortController timeout. Throws a user-friendly error on timeout. */
+async function fetchWithTimeout(url: string, init: RequestInit = {}): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') {
+      throw new Error('Server did not respond. Check the server URL and your connection.');
+    }
+    // Network error (DNS failure, connection refused, etc.)
+    throw new Error('Cannot reach server. Is it running and the URL correct?');
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// State (Svelte 5 runes)
+// ---------------------------------------------------------------------------
+
+let _accessToken = $state<string | null>(null);
+let _dek = $state<CryptoKey | null>(null);
+let _userId = $state<string | null>(null);
+let _username = $state<string | null>(null);
+let _serverUrl = $state<string>(loadLastServer());
+let _savedServers = $state<string[]>(loadSavedServers());
+let _loading = $state(false);
+let _error = $state<string | null>(null);
+
+// ---------------------------------------------------------------------------
+// Exported reactive getters
+// ---------------------------------------------------------------------------
+
+export const auth = {
+  get accessToken() { return _accessToken; },
+  get dek() { return _dek; },
+  get userId() { return _userId; },
+  get username() { return _username; },
+  get serverUrl() { return _serverUrl; },
+  get savedServers() { return _savedServers; },
+  get loading() { return _loading; },
+  get error() { return _error; },
+  get isLoggedIn() { return _accessToken !== null && _dek !== null; },
+};
+
+// ---------------------------------------------------------------------------
+// Server URL management
+// ---------------------------------------------------------------------------
+
+function loadLastServer(): string {
+  if (typeof localStorage === 'undefined') return DEFAULT_SERVER;
+  return localStorage.getItem(LS_LAST_SERVER_KEY) ?? DEFAULT_SERVER;
+}
+
+function loadSavedServers(): string[] {
+  if (typeof localStorage === 'undefined') return [DEFAULT_SERVER];
+  try {
+    const raw = localStorage.getItem(LS_SERVERS_KEY);
+    const list = raw ? (JSON.parse(raw) as string[]) : [DEFAULT_SERVER];
+    if (!list.includes(DEFAULT_SERVER)) list.unshift(DEFAULT_SERVER);
+    return list;
+  } catch {
+    return [DEFAULT_SERVER];
+  }
+}
+
+/**
+ * Normalise any form of server URL the user might type:
+ *   "10.66.66.1"          → "http://10.66.66.1"
+ *   "10.66.66.1:3000"     → "http://10.66.66.1:3000"
+ *   "192.168.1.5"         → "http://192.168.1.5"
+ *   "notes.example.com"   → "https://notes.example.com"
+ *   "https://foo.com/"    → "https://foo.com"
+ *   "http://foo.com"      → "http://foo.com"
+ *
+ * Rules:
+ *   - If the input already has http:// or https://, keep it as-is.
+ *   - If the input looks like an IP address (v4), default to http://.
+ *   - Otherwise (domain name), default to https://.
+ *   - Always strip trailing slash.
+ */
+export function normaliseServerUrl(raw: string): string {
+  const trimmed = raw.trim().replace(/\/$/, '');
+  if (!trimmed) return DEFAULT_SERVER;
+
+  // Already has a scheme
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+
+  // Looks like an IPv4 address (with optional port)
+  const ipv4Re = /^(\d{1,3}\.){3}\d{1,3}(:\d+)?$/;
+  if (ipv4Re.test(trimmed)) return `http://${trimmed}`;
+
+  // localhost / 127.x.x.x
+  if (trimmed.startsWith('localhost') || trimmed.startsWith('127.')) return `http://${trimmed}`;
+
+  // Default: assume https for domain names
+  return `https://${trimmed}`;
+}
+
+export function setServerUrl(url: string): void {
+  const normalized = normaliseServerUrl(url) || DEFAULT_SERVER;
+  _serverUrl = normalized;
+  localStorage.setItem(LS_LAST_SERVER_KEY, normalized);
+
+  // Add to saved list if not already there
+  if (!_savedServers.includes(normalized)) {
+    _savedServers = [normalized, ..._savedServers];
+    localStorage.setItem(LS_SERVERS_KEY, JSON.stringify(_savedServers));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Health check
+// ---------------------------------------------------------------------------
+
+export type ServerStatus = 'unknown' | 'checking' | 'online' | 'offline';
+
+let _serverStatus = $state<ServerStatus>('unknown');
+export const serverStatus = { get value() { return _serverStatus; } };
+
+/**
+ * Ping GET /health on the given (or current) server URL.
+ * Updates the reactive _serverStatus.
+ * Resolves to true if the server responded OK, false otherwise.
+ * Has a 5-second timeout.
+ */
+export async function checkServerHealth(url?: string): Promise<boolean> {
+  const target = url ? normaliseServerUrl(url) : _serverUrl;
+  _serverStatus = 'checking';
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 5000);
+    const res = await fetch(`${target}/health`, {
+      signal: controller.signal,
+      cache: 'no-store',
+    });
+    clearTimeout(timer);
+    _serverStatus = res.ok ? 'online' : 'offline';
+    return res.ok;
+  } catch {
+    _serverStatus = 'offline';
+    return false;
+  }
+}
+
+export function removeSavedServer(url: string): void {
+  if (url === DEFAULT_SERVER) return; // never remove default
+  _savedServers = _savedServers.filter((s) => s !== url);
+  localStorage.setItem(LS_SERVERS_KEY, JSON.stringify(_savedServers));
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Authenticated fetch with automatic token refresh on 401.
+ * Always sends the access token from memory; never from localStorage.
+ * Credentials: 'include' sends the httpOnly refresh cookie on all requests.
+ */
+export async function apiFetch(
+  path: string,
+  init: RequestInit = {}
+): Promise<Response> {
+  const url = `${_serverUrl}${path}`;
+  const headers = new Headers(init.headers);
+  if (_accessToken) {
+    headers.set('Authorization', `Bearer ${_accessToken}`);
+  }
+  headers.set('Content-Type', 'application/json');
+
+  const res = await fetch(url, {
+    ...init,
+    headers,
+    credentials: 'include', // send httpOnly refresh cookie
+  });
+
+  // On 401, attempt token refresh once
+  if (res.status === 401 && _accessToken) {
+    const refreshed = await tryRefreshToken();
+    if (refreshed) {
+      headers.set('Authorization', `Bearer ${_accessToken}`);
+      return fetch(url, { ...init, headers, credentials: 'include' });
+    }
+    // Refresh failed — force logout
+    await logout();
+    goto('/login');
+  }
+
+  return res;
+}
+
+// ---------------------------------------------------------------------------
+// Token refresh
+// ---------------------------------------------------------------------------
+
+async function tryRefreshToken(): Promise<boolean> {
+  try {
+    const res = await fetch(`${_serverUrl}/api/auth/refresh`, {
+      method: 'POST',
+      credentials: 'include',
+    });
+    if (!res.ok) return false;
+    const data = await res.json() as { accessToken: string };
+    _accessToken = data.accessToken;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+/**
+ * Register a new account.
+ *
+ * 1. Generate DEK (random 32 bytes)
+ * 2. Derive Master Key from password + random dekSalt
+ * 3. Wrap DEK with Master Key → encryptedDek
+ * 4. Generate SRP salt + verifier from password
+ * 5. POST to /api/auth/register
+ * 6. On success, save key material to IndexedDB for offline use
+ */
+export async function register(username: string, password: string): Promise<void> {
+  _loading = true;
+  _error = null;
+
+  try {
+    // Client-side validation
+    if (username.trim().length < 3) throw new Error('Username must be at least 3 characters.');
+    if (password.length < 8) throw new Error('Password must be at least 8 characters.');
+    // Key material
+    const dekSaltBytes = randomBytes(32);
+    const dekSaltHex = toHex(dekSaltBytes);
+    const masterKey = await deriveMasterKey(password, dekSaltBytes);
+    const { dek, dekRaw } = await generateDek();
+    const encryptedDek = await wrapDek(dekRaw, masterKey);
+
+    // SRP verifier
+    const { salt: srpSalt, verifier } = await srpRegister(username, password);
+
+    // POST to server
+    const res = await fetchWithTimeout(`${_serverUrl}/api/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({
+        username,
+        srpSalt,
+        verifier,
+        encryptedDek,
+        dekSalt: dekSaltHex,
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({})) as { message?: string };
+      if (res.status === 409) throw new Error('Username already taken. Choose a different one.');
+      if (res.status === 400) throw new Error(body.message ?? 'Invalid registration details.');
+      if (res.status >= 500) throw new Error('Server error. Please try again later.');
+      throw new Error(body.message ?? 'Registration failed.');
+    }
+
+    const data = await res.json() as {
+      accessToken: string;
+      userId: string;
+      username: string;
+    };
+
+    // Store DEK and access token in memory
+    _accessToken = data.accessToken;
+    _dek = dek;
+    _userId = data.userId;
+    _username = data.username;
+
+    // Save key material to IndexedDB for next login (allows offline DEK restore)
+    await saveKeyMaterial({
+      id: 'current',
+      username,
+      serverUrl: _serverUrl,
+      encryptedDek,
+      dekSaltHex,
+    });
+
+    setServerUrl(_serverUrl); // persist server URL
+
+  } catch (err) {
+    _error = (err as Error).message;
+    throw err;
+  } finally {
+    _loading = false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Login (SRP-6a two-step)
+// ---------------------------------------------------------------------------
+
+/**
+ * Log in with SRP-6a.
+ *
+ * Step 1: Send username + A to server → receive salt + B
+ * Step 2: Compute M1 + session key, send M1 → receive access token + M2
+ * Step 3: Verify M2 (proves server knows password)
+ * Step 4: Derive master key → unwrap DEK from encryptedDek
+ */
+export async function login(username: string, password: string): Promise<void> {
+  _loading = true;
+  _error = null;
+
+  try {
+    // --- Step 1: Client ephemeral ---
+    const { a, A } = srpClientEphemeral();
+
+    const initRes = await fetchWithTimeout(`${_serverUrl}/api/auth/login/init`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, A }),
+    });
+
+    if (!initRes.ok) {
+      if (initRes.status === 429) throw new Error('Too many login attempts. Please wait a minute and try again.');
+      if (initRes.status >= 500) throw new Error('Server error. Please try again later.');
+      // Intentionally vague for 400/404 — don't reveal whether username exists
+      throw new Error('Invalid username or password.');
+    }
+
+    const initData = await initRes.json() as {
+      salt: string;
+      B: string;
+    };
+
+    // --- Step 2: Client proof ---
+    const { M1, sessionKey } = await srpClientProof({
+      username,
+      password,
+      saltHex: initData.salt,
+      AHex: A,
+      BHex: initData.B,
+      a,
+    });
+
+    const verifyRes = await fetchWithTimeout(`${_serverUrl}/api/auth/login/verify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include', // receive httpOnly refresh cookie
+      body: JSON.stringify({ username, A, M1 }),
+    });
+
+    if (!verifyRes.ok) {
+      if (verifyRes.status === 429) throw new Error('Too many login attempts. Please wait a minute and try again.');
+      if (verifyRes.status >= 500) throw new Error('Server error. Please try again later.');
+      throw new Error('Invalid username or password.');
+    }
+
+    const verifyData = await verifyRes.json() as {
+      accessToken: string;
+      M2: string;
+      userId: string;
+      username: string;
+      encryptedDek: string;
+      dekSalt: string; // hex
+    };
+
+    // --- Step 3: Verify server proof (mutual authentication) ---
+    try {
+      await srpVerifyServer(A, M1, sessionKey, verifyData.M2);
+    } catch {
+      throw new Error('Login failed: server verification error. Please try again.');
+    }
+
+    // --- Step 4: Unwrap DEK ---
+    const dekSaltBytes = fromHex(verifyData.dekSalt);
+    const masterKey = await deriveMasterKey(password, dekSaltBytes);
+    const dek = await unwrapDek(verifyData.encryptedDek, masterKey);
+
+    // Store in memory
+    _accessToken = verifyData.accessToken;
+    _dek = dek;
+    _userId = verifyData.userId;
+    _username = verifyData.username;
+
+    // Persist key material for offline DEK restore
+    await saveKeyMaterial({
+      id: 'current',
+      username,
+      serverUrl: _serverUrl,
+      encryptedDek: verifyData.encryptedDek,
+      dekSaltHex: verifyData.dekSalt,
+    });
+
+    setServerUrl(_serverUrl);
+
+  } catch (err) {
+    _error = (err as Error).message;
+    throw err;
+  } finally {
+    _loading = false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Logout
+// ---------------------------------------------------------------------------
+
+export async function logout(): Promise<void> {
+  const userId = _userId;
+
+  // Clear memory first
+  _accessToken = null;
+  _dek = null;
+  _userId = null;
+  _username = null;
+
+  // Revoke server session (best-effort; don't block on failure)
+  try {
+    await fetch(`${_serverUrl}/api/auth/logout`, {
+      method: 'POST',
+      credentials: 'include',
+    });
+  } catch {
+    // Offline logout — session will expire naturally
+  }
+
+  // Wipe local IndexedDB data
+  if (userId) {
+    try {
+      await wipeLocalData(userId);
+    } catch {
+      // Ignore wipe errors — worst case stale data remains
+    }
+  }
+
+  await clearKeyMaterial();
+}
+
+// ---------------------------------------------------------------------------
+// Restore session on page load
+// ---------------------------------------------------------------------------
+
+/**
+ * Try to restore the session from the httpOnly refresh cookie.
+ * Called once in +layout.svelte on mount.
+ *
+ * If the refresh token is still valid, the server issues a new access token.
+ * We then load cached key material from IndexedDB (encryptedDek + dekSalt)
+ * but we CAN'T re-derive the DEK without the password!
+ *
+ * Resolution: after restoring the access token, we stay in a "locked" state
+ * where the DEK is null. The app prompts the user to re-enter their password
+ * to "unlock" the vault (like Bitwarden's vault unlock screen).
+ *
+ * `isLoggedIn` checks both accessToken AND dek — so a locked state will
+ * redirect to /login where the user can unlock with their password.
+ * The login form detects that a session exists and shows "Unlock" instead of "Log in".
+ */
+export async function restoreSession(): Promise<void> {
+  const refreshed = await tryRefreshToken();
+  if (!refreshed) return;
+
+  // Load saved identity from IndexedDB
+  const km = await loadKeyMaterial();
+  if (km) {
+    _username = km.username;
+    _serverUrl = km.serverUrl;
+    // _dek remains null — user must unlock with password
+  }
+
+  // Get userId from the access token (decode without verify — browser already verified via HTTPS)
+  if (_accessToken) {
+    try {
+      const payload = JSON.parse(atob(_accessToken.split('.')[1])) as { sub: string };
+      _userId = payload.sub;
+    } catch {
+      // Malformed token — treat as logged out
+      _accessToken = null;
+    }
+  }
+}
+
+/**
+ * Unlock the vault with the user's password.
+ * Used when session is restored but DEK is not in memory.
+ *
+ * @throws if password is wrong (DEK decryption will fail)
+ */
+export async function unlockWithPassword(password: string): Promise<void> {
+  _loading = true;
+  _error = null;
+
+  try {
+    const km = await loadKeyMaterial();
+    if (!km) throw new Error('No local key material — please log in again');
+
+    const dekSaltBytes = fromHex(km.dekSaltHex);
+    const masterKey = await deriveMasterKey(password, dekSaltBytes);
+    const dek = await unwrapDek(km.encryptedDek, masterKey);
+
+    _dek = dek;
+  } finally {
+    _loading = false;
+  }
+}

--- a/bedroc/src/lib/stores/notes.svelte.ts
+++ b/bedroc/src/lib/stores/notes.svelte.ts
@@ -1,364 +1,716 @@
 /**
- * notes.svelte.ts — In-memory note, topic, and folder store (Phase 0 / Phase 1 shell).
+ * notes.svelte.ts — Offline-first note, topic, and folder store.
  *
- * PLACEHOLDERS (replace in Phase 2):
- *  - All data is in-memory only; no IndexedDB or server persistence.
- *  - saveNote / deleteNote / saveTopic / deleteTopic only mutate local maps.
- *  - Note body is stored as raw HTML from contenteditable; in Phase 2 this
- *    must be AES-GCM encrypted before leaving the device.
- *  - autosave.interval is read from localStorage; defaults to 1000ms.
- *    Real setting persistence wired in Phase 5.
- *  - sortMode and customOrder are persisted to localStorage only.
- *    Move to server-backed user preferences in Phase 5.
+ * Architecture:
+ *   Primary store: IndexedDB (all reads/writes hit IndexedDB first)
+ *   Secondary store: Server (sync target; notes encrypted before leaving device)
  *
- * ID strategy:
- *  - All note, topic, and folder IDs are crypto.randomUUID() — client-generated.
- *  - Static UUIDs are used for demo data to avoid calling crypto at module
- *    evaluation time, which throws during SSR.
- *  - The server (Phase 2) will store the client UUID as the primary key.
+ * Write path:
+ *   1. Encrypt title + body with DEK (AES-256-GCM)
+ *   2. Write plaintext to IndexedDB (local, client-only)
+ *   3. Enqueue encrypted payload to syncQueue in IndexedDB
+ *   4. Mark note as `synced: false` in IndexedDB
+ *   5. Attempt server PUT (if online)
+ *   6. On success → mark `synced: true`, dequeue
+ *   7. On failure → leave in syncQueue; retried by flushSyncQueue()
+ *
+ * Read path:
+ *   1. Load from IndexedDB (instant, works offline)
+ *   2. On mount, trigger delta sync from server (getNotesSince last sync)
+ *   3. Decrypt incoming server notes, merge into IndexedDB and reactive maps
+ *
+ * Reactive maps (SvelteMap) provide granular DOM reactivity.
+ * All async operations update maps after completion.
  */
 
 import { SvelteMap } from 'svelte/reactivity';
+import { auth, apiFetch } from './auth.svelte.js';
+import { encryptNote, decryptNote } from '$lib/crypto/encrypt.js';
+import {
+  saveNote as idbSaveNote,
+  getNotesByUser,
+  getNotesByTopic as idbGetNotesByTopic,
+  markNoteDeleted as idbMarkDeleted,
+  saveTopic as idbSaveTopic,
+  getTopicsByUser,
+  deleteTopic as idbDeleteTopic,
+  saveFolder as idbSaveFolder,
+  getFoldersByUser,
+  deleteFolder as idbDeleteFolder,
+  enqueueSyncItem,
+  dequeueSyncItem,
+  getAllSyncQueue,
+  incrementRetry,
+  type NoteLocal,
+  type TopicLocal,
+  type FolderLocal,
+  type SyncQueueItem,
+} from '$lib/db/indexeddb.js';
 
-// ─── Types ────────────────────────────────────────────────────────
+// ---------------------------------------------------------------------------
+// Re-export types used by UI components (maintain same interface shape)
+// ---------------------------------------------------------------------------
 
-export interface Folder {
-	id: string;
-	name: string;
-	/** null = root level (no parent folder) */
-	parentId: string | null;
-	/** Ascending integer — lower = higher in the list */
-	order: number;
-	collapsed: boolean;
+export interface Note {
+  id: string;
+  title: string;
+  body: string;
+  topicId: string | null;
+  createdAt: number;
+  updatedAt: number;
+  customOrder: number;
 }
 
 export interface Topic {
-	id: string;
-	name: string;
-	/** CSS color string — any valid CSS color (hex, hsl, etc.) */
-	color: string;
-	/** null = unfiled (not inside any folder) */
-	folderId: string | null;
-	/** Ascending integer — lower = higher within its folder group */
-	order: number;
+  id: string;
+  name: string;
+  color: string;
+  folderId: string | null;
+  order: number;
 }
 
-export interface Note {
-	id: string;
-	title: string;
-	/** Raw HTML from contenteditable — PLACEHOLDER: must be encrypted in Phase 2 */
-	body: string;
-	topicId: string | null;
-	createdAt: number;   // Unix ms
-	updatedAt: number;   // Unix ms
-	/**
-	 * Position in the custom sort order within its topic group.
-	 * Only used when sortMode === 'custom'. Lower = higher in list.
-	 * PLACEHOLDER: persisted to localStorage. Move to server in Phase 5.
-	 */
-	customOrder: number;
+export interface Folder {
+  id: string;
+  name: string;
+  parentId: string | null;
+  order: number;
+  collapsed: boolean;
 }
 
-/** How the note list is sorted. Persisted to localStorage. */
 export type SortMode = 'recent' | 'alpha' | 'custom';
 
-// ─── Demo data (static IDs — no crypto at module eval time) ───────
-// PLACEHOLDER: removed and replaced with empty arrays in Phase 2.
+// ---------------------------------------------------------------------------
+// Reactive maps
+// ---------------------------------------------------------------------------
 
-const F_WORK_FOLDER = 'f1000000-0000-0000-0000-000000000001';
+export const notesMap = new SvelteMap<string, Note>();
+export const topicsMap = new SvelteMap<string, Topic>();
+export const foldersMap = new SvelteMap<string, Folder>();
 
-const DEFAULT_FOLDERS: Folder[] = [
-	{ id: F_WORK_FOLDER, name: 'Work projects', parentId: null, order: 0, collapsed: false },
-];
+let _syncing = $state(false);
+export const syncState = { get syncing() { return _syncing; } };
 
-const T_PERSONAL = 'a1000000-0000-0000-0000-000000000001';
-const T_WORK     = 'a1000000-0000-0000-0000-000000000002';
-const T_IDEAS    = 'a1000000-0000-0000-0000-000000000003';
-
-const DEFAULT_TOPICS: Topic[] = [
-	{ id: T_PERSONAL, name: 'Personal', color: '#6b8afd', folderId: null,         order: 0 },
-	{ id: T_WORK,     name: 'Work',     color: '#4caf87', folderId: F_WORK_FOLDER, order: 0 },
-	{ id: T_IDEAS,    name: 'Ideas',    color: '#e0a45c', folderId: null,          order: 1 },
-];
-
-const DEFAULT_NOTES: Note[] = [
-	{
-		id: 'b1000000-0000-0000-0000-000000000001',
-		title: 'Shopping list',
-		body: '<p>Milk, eggs, bread, coffee, olive oil</p><ul><li>Milk</li><li>Eggs</li><li>Bread</li><li>Coffee</li></ul>',
-		topicId: T_PERSONAL,
-		createdAt: Date.now() - 86400000,
-		updatedAt: Date.now() - 120000,
-		customOrder: 0,
-	},
-	{
-		id: 'b1000000-0000-0000-0000-000000000002',
-		title: 'Meeting notes',
-		body: '<p><strong>Q3 goals</strong> — action items from last week</p><ul><li>Follow up with design team</li><li>Update the roadmap doc</li><li>Schedule weekly sync</li></ul>',
-		topicId: T_WORK,
-		createdAt: Date.now() - 172800000,
-		updatedAt: Date.now() - 3600000,
-		customOrder: 0,
-	},
-	{
-		id: 'b1000000-0000-0000-0000-000000000003',
-		title: 'Feature ideas',
-		body: '<p>New feature concepts for the project:</p><ol><li>Offline-first sync with conflict resolution</li><li>Shared encrypted notes via asymmetric keys</li><li>Markdown export</li></ol>',
-		topicId: T_IDEAS,
-		createdAt: Date.now() - 259200000,
-		updatedAt: Date.now() - 86400000,
-		customOrder: 0,
-	},
-	{
-		id: 'b1000000-0000-0000-0000-000000000004',
-		title: 'Quick note',
-		body: '<p>Remember to check the deployment configs before Friday.</p>',
-		topicId: null,
-		createdAt: Date.now() - 300000,
-		updatedAt: Date.now() - 300000,
-		customOrder: 0,
-	},
-];
-
-// ─── Reactive stores ───────────────────────────────────────────────
-// SvelteMap provides fine-grained reactivity; all keyed by ID.
-
-export const foldersMap = new SvelteMap<string, Folder>(
-	DEFAULT_FOLDERS.map((f) => [f.id, f])
-);
-
-export const topicsMap = new SvelteMap<string, Topic>(
-	DEFAULT_TOPICS.map((t) => [t.id, t])
-);
-
-export const notesMap = new SvelteMap<string, Note>(
-	DEFAULT_NOTES.map((n) => [n.id, n])
-);
-
-// ─── Autosave setting ─────────────────────────────────────────────
-// Class instance pattern — required in .svelte.ts modules because
-// `export let x = $state(...)` with reassignment is not allowed by the
-// Svelte 5 compiler when the binding crosses module boundaries.
-
-function readAutosaveInterval(): number {
-	if (typeof localStorage === 'undefined') return 1000;
-	const raw = localStorage.getItem('bedroc_autosave_ms');
-	const parsed = raw ? parseInt(raw, 10) : NaN;
-	return Number.isFinite(parsed) && parsed >= 0 ? parsed : 1000;
-}
-
-class AutosaveStore {
-	interval = $state(readAutosaveInterval());
-
-	set(ms: number) {
-		this.interval = ms;
-		if (typeof localStorage !== 'undefined') {
-			localStorage.setItem('bedroc_autosave_ms', String(ms));
-		}
-	}
-}
-
-export const autosave = new AutosaveStore();
-
-// ─── Sort mode setting ─────────────────────────────────────────────
-// PLACEHOLDER: persisted to localStorage only. Phase 5: server preferences.
+// ---------------------------------------------------------------------------
+// Sort mode (localStorage — user pref, not encrypted)
+// ---------------------------------------------------------------------------
 
 function readSortMode(): SortMode {
-	if (typeof localStorage === 'undefined') return 'recent';
-	const raw = localStorage.getItem('bedroc_sort_mode');
-	if (raw === 'alpha' || raw === 'custom' || raw === 'recent') return raw;
-	return 'recent';
+  if (typeof localStorage === 'undefined') return 'recent';
+  const raw = localStorage.getItem('bedroc_sort_mode');
+  if (raw === 'alpha' || raw === 'custom' || raw === 'recent') return raw;
+  return 'recent';
 }
 
 class SortModeStore {
-	value = $state<SortMode>(readSortMode());
-
-	set(mode: SortMode) {
-		this.value = mode;
-		if (typeof localStorage !== 'undefined') {
-			localStorage.setItem('bedroc_sort_mode', mode);
-		}
-	}
+  value = $state<SortMode>(readSortMode());
+  set(mode: SortMode) {
+    this.value = mode;
+    if (typeof localStorage !== 'undefined') localStorage.setItem('bedroc_sort_mode', mode);
+  }
 }
-
 export const sortModeStore = new SortModeStore();
 
-// ─── Folder mutations ─────────────────────────────────────────────
+// ---------------------------------------------------------------------------
+// Autosave (localStorage — user pref)
+// ---------------------------------------------------------------------------
 
-/** Create a new folder and return its UUID. */
-export function createFolder(name: string, parentId: string | null = null): string {
-	const id = crypto.randomUUID();
-	const siblings = getFolders().filter((f) => f.parentId === parentId);
-	const order = siblings.length > 0 ? Math.max(...siblings.map((f) => f.order)) + 1 : 0;
-	foldersMap.set(id, { id, name, parentId, order, collapsed: false });
-	return id;
+function readAutosaveInterval(): number {
+  if (typeof localStorage === 'undefined') return 1000;
+  const raw = localStorage.getItem('bedroc_autosave_ms');
+  const parsed = raw ? parseInt(raw, 10) : NaN;
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 1000;
 }
 
-/** Update an existing folder. */
-export function saveFolder(folder: Folder) {
-	foldersMap.set(folder.id, folder);
+class AutosaveStore {
+  interval = $state(readAutosaveInterval());
+  set(ms: number) {
+    this.interval = ms;
+    if (typeof localStorage !== 'undefined') localStorage.setItem('bedroc_autosave_ms', String(ms));
+  }
+}
+export const autosave = new AutosaveStore();
+
+// ---------------------------------------------------------------------------
+// Load from IndexedDB on login
+// ---------------------------------------------------------------------------
+
+/** Load all data from IndexedDB into reactive maps. Call once after login. */
+export async function loadFromDb(): Promise<void> {
+  const userId = auth.userId;
+  if (!userId) return;
+
+  const [notes, topics, folders] = await Promise.all([
+    getNotesByUser(userId),
+    getTopicsByUser(userId),
+    getFoldersByUser(userId),
+  ]);
+
+  notesMap.clear();
+  topicsMap.clear();
+  foldersMap.clear();
+
+  for (const n of notes) {
+    notesMap.set(n.id, localToNote(n));
+  }
+  for (const t of topics) {
+    topicsMap.set(t.id, localToTopic(t));
+  }
+  for (const f of folders) {
+    foldersMap.set(f.id, localToFolder(f));
+  }
 }
 
-/** Toggle a folder's collapsed state. */
-export function toggleFolderCollapsed(id: string) {
-	const f = foldersMap.get(id);
-	if (f) foldersMap.set(id, { ...f, collapsed: !f.collapsed });
+/** Clear reactive maps on logout. */
+export function clearStore(): void {
+  notesMap.clear();
+  topicsMap.clear();
+  foldersMap.clear();
 }
 
-/**
- * Delete a folder. Child folders are moved to the deleted folder's parent.
- * Topics inside the folder become unfiled.
- */
-export function deleteFolder(id: string) {
-	const folder = foldersMap.get(id);
-	if (!folder) return;
-	for (const [fid, f] of foldersMap) {
-		if (f.parentId === id) foldersMap.set(fid, { ...f, parentId: folder.parentId });
-	}
-	for (const [tid, t] of topicsMap) {
-		if (t.folderId === id) topicsMap.set(tid, { ...t, folderId: null });
-	}
-	foldersMap.delete(id);
+// ---------------------------------------------------------------------------
+// Delta sync from server
+// ---------------------------------------------------------------------------
+
+/** Key in localStorage tracking last successful sync timestamp. */
+const LAST_SYNC_KEY = 'bedroc_last_sync';
+
+function getLastSync(): string {
+  if (typeof localStorage === 'undefined') return new Date(0).toISOString();
+  return localStorage.getItem(LAST_SYNC_KEY) ?? new Date(0).toISOString();
 }
 
-/** Move a folder to a new parent and reorder. */
-export function moveFolder(id: string, newParentId: string | null, afterId?: string) {
-	const folder = foldersMap.get(id);
-	if (!folder) return;
-	const siblings = getFolders()
-		.filter((f) => f.parentId === newParentId && f.id !== id)
-		.sort((a, b) => a.order - b.order);
-	const insertIdx = afterId ? siblings.findIndex((f) => f.id === afterId) + 1 : 0;
-	siblings.splice(insertIdx, 0, { ...folder, parentId: newParentId });
-	siblings.forEach((f, i) => foldersMap.set(f.id, { ...f, order: i }));
-}
-
-// ─── Topic mutations ──────────────────────────────────────────────
-
-/** Create a new topic and return its UUID. */
-export function createTopic(name: string, color: string, folderId: string | null = null): string {
-	const id = crypto.randomUUID();
-	const siblings = getTopics().filter((t) => t.folderId === folderId);
-	const order = siblings.length > 0 ? Math.max(...siblings.map((t) => t.order)) + 1 : 0;
-	topicsMap.set(id, { id, name, color, folderId, order });
-	return id;
-}
-
-/** Update an existing topic. */
-export function saveTopic(topic: Topic) {
-	topicsMap.set(topic.id, topic);
-}
-
-/**
- * Delete a topic and unassign its notes.
- * PLACEHOLDER: no server call.
- */
-export function deleteTopic(id: string) {
-	topicsMap.delete(id);
-	for (const [nid, note] of notesMap) {
-		if (note.topicId === id) notesMap.set(nid, { ...note, topicId: null });
-	}
-}
-
-/** Move a topic to a different folder and/or reorder it. */
-export function moveTopic(id: string, newFolderId: string | null, afterId?: string) {
-	const topic = topicsMap.get(id);
-	if (!topic) return;
-	const siblings = getTopics()
-		.filter((t) => t.folderId === newFolderId && t.id !== id)
-		.sort((a, b) => a.order - b.order);
-	const insertIdx = afterId ? siblings.findIndex((t) => t.id === afterId) + 1 : 0;
-	siblings.splice(insertIdx, 0, { ...topic, folderId: newFolderId });
-	siblings.forEach((t, i) => topicsMap.set(t.id, { ...t, order: i }));
-}
-
-// ─── Note mutations ───────────────────────────────────────────────
-
-/** Create a new note and return its UUID. */
-export function createNote(topicId: string | null = null): string {
-	const id = crypto.randomUUID();
-	const siblings = [...notesMap.values()].filter(n => n.topicId === topicId);
-	const nextOrder = siblings.length > 0 ? Math.max(...siblings.map(n => n.customOrder)) + 1 : 0;
-	notesMap.set(id, {
-		id,
-		title: '',
-		body: '',
-		topicId,
-		createdAt: Date.now(),
-		updatedAt: Date.now(),
-		customOrder: nextOrder,
-	});
-	return id;
-}
-
-/** Save (upsert) a note. PLACEHOLDER: no encryption or server call. */
-export function saveNote(note: Note) {
-	notesMap.set(note.id, { ...note, updatedAt: Date.now() });
-}
-
-/** Soft-delete a note. PLACEHOLDER: no server call. */
-export function deleteNote(id: string) {
-	notesMap.delete(id);
+function setLastSync(iso: string): void {
+  if (typeof localStorage !== 'undefined') localStorage.setItem(LAST_SYNC_KEY, iso);
 }
 
 /**
- * Reorder a note in custom sort mode.
- * Moves `id` to appear after `afterId` within its topic group.
- * If afterId is null, moves the note to the top.
+ * Pull changes from the server since last sync, decrypt and merge locally.
+ * Safe to call at any time; skips if no DEK is available.
  */
-export function reorderNote(id: string, afterId: string | null) {
-	const note = notesMap.get(id);
-	if (!note) return;
-	const siblings = [...notesMap.values()]
-		.filter(n => n.topicId === note.topicId && n.id !== id)
-		.sort((a, b) => a.customOrder - b.customOrder);
-	const insertIdx = afterId ? siblings.findIndex(n => n.id === afterId) + 1 : 0;
-	siblings.splice(insertIdx, 0, { ...note });
-	siblings.forEach((n, i) => notesMap.set(n.id, { ...n, customOrder: i }));
+export async function syncFromServer(): Promise<void> {
+  const dek = auth.dek;
+  const userId = auth.userId;
+  if (!dek || !userId || _syncing) return;
+
+  _syncing = true;
+  try {
+    const since = getLastSync();
+    const res = await apiFetch(`/api/notes/sync?since=${encodeURIComponent(since)}`);
+    if (!res.ok) return;
+
+    const data = await res.json() as {
+      notes: ServerNote[];
+      syncedAt: string;
+    };
+
+    // Decrypt and merge each note
+    for (const sn of data.notes) {
+      const { title, body } = await decryptNote(sn.encrypted_title, sn.encrypted_body, dek);
+
+      const local: NoteLocal = {
+        id: sn.id,
+        userId,
+        topicId: sn.topic_id,
+        title,
+        body,
+        customOrder: sn.custom_order,
+        clientUpdatedAt: new Date(sn.client_updated_at).getTime(),
+        serverUpdatedAt: new Date(sn.server_updated_at).getTime(),
+        isDeleted: sn.is_deleted,
+        version: sn.version,
+        synced: true,
+      };
+
+      await idbSaveNote(local);
+
+      if (sn.is_deleted) {
+        notesMap.delete(sn.id);
+      } else {
+        notesMap.set(sn.id, localToNote(local));
+      }
+    }
+
+    setLastSync(data.syncedAt);
+
+    // Also sync topics and folders
+    await syncTopicsFromServer();
+    await syncFoldersFromServer();
+
+    // Flush any pending writes queued while offline
+    await flushSyncQueue();
+  } finally {
+    _syncing = false;
+  }
 }
 
-// ─── Derived helpers ──────────────────────────────────────────────
+async function syncTopicsFromServer(): Promise<void> {
+  const res = await apiFetch('/api/topics');
+  if (!res.ok) return;
+  const topics = await res.json() as ServerTopic[];
+  const userId = auth.userId!;
 
-/** All folders sorted by order within each parent group. */
+  topicsMap.clear();
+  for (const st of topics) {
+    const local: TopicLocal = {
+      id: st.id,
+      userId,
+      name: st.name,
+      color: st.color,
+      folderId: st.folder_id,
+      sortOrder: st.sort_order,
+      synced: true,
+    };
+    await idbSaveTopic(local);
+    topicsMap.set(st.id, localToTopic(local));
+  }
+}
+
+async function syncFoldersFromServer(): Promise<void> {
+  const res = await apiFetch('/api/folders');
+  if (!res.ok) return;
+  const folders = await res.json() as ServerFolder[];
+  const userId = auth.userId!;
+
+  foldersMap.clear();
+  for (const sf of folders) {
+    const local: FolderLocal = {
+      id: sf.id,
+      userId,
+      name: sf.name,
+      parentId: sf.parent_id,
+      sortOrder: sf.sort_order,
+      collapsed: sf.collapsed,
+      synced: true,
+    };
+    await idbSaveFolder(local);
+    foldersMap.set(sf.id, localToFolder(local));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Flush sync queue (offline writes)
+// ---------------------------------------------------------------------------
+
+const MAX_RETRIES = 5;
+
+export async function flushSyncQueue(): Promise<void> {
+  const queue = await getAllSyncQueue();
+  for (const item of queue) {
+    if (item.retries >= MAX_RETRIES) continue; // give up after 5 attempts
+    try {
+      if (item.type === 'note') {
+        if (item.action === 'upsert') {
+          const res = await apiFetch(`/api/notes/${item.id}`, {
+            method: 'PUT',
+            body: JSON.stringify(item.payload),
+          });
+          if (res.ok) {
+            await dequeueSyncItem(item.id);
+            // Mark as synced in IndexedDB
+            const existing = notesMap.get(item.id);
+            if (existing) {
+              const n = await import('$lib/db/indexeddb.js').then(m => m.getNoteById(item.id));
+              if (n) await idbSaveNote({ ...n, synced: true });
+            }
+          } else {
+            await incrementRetry(item.id);
+          }
+        } else if (item.action === 'delete') {
+          const res = await apiFetch(`/api/notes/${item.id}`, { method: 'DELETE' });
+          if (res.ok) await dequeueSyncItem(item.id);
+          else await incrementRetry(item.id);
+        }
+      } else if (item.type === 'topic') {
+        if (item.action === 'upsert') {
+          const res = await apiFetch(`/api/topics/${item.id}`, {
+            method: 'PUT',
+            body: JSON.stringify(item.payload),
+          });
+          if (res.ok) await dequeueSyncItem(item.id);
+          else await incrementRetry(item.id);
+        } else if (item.action === 'delete') {
+          const res = await apiFetch(`/api/topics/${item.id}`, { method: 'DELETE' });
+          if (res.ok) await dequeueSyncItem(item.id);
+          else await incrementRetry(item.id);
+        }
+      } else if (item.type === 'folder') {
+        if (item.action === 'upsert') {
+          const res = await apiFetch(`/api/folders/${item.id}`, {
+            method: 'PUT',
+            body: JSON.stringify(item.payload),
+          });
+          if (res.ok) await dequeueSyncItem(item.id);
+          else await incrementRetry(item.id);
+        } else if (item.action === 'delete') {
+          const res = await apiFetch(`/api/folders/${item.id}`, { method: 'DELETE' });
+          if (res.ok) await dequeueSyncItem(item.id);
+          else await incrementRetry(item.id);
+        }
+      }
+    } catch {
+      await incrementRetry(item.id);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Note mutations
+// ---------------------------------------------------------------------------
+
+/** Create a new note, persist to IndexedDB, sync to server. */
+export async function createNote(topicId: string | null = null): Promise<string> {
+  const id = crypto.randomUUID();
+  const userId = auth.userId!;
+  const dek = auth.dek!;
+
+  const now = Date.now();
+  const siblings = [...notesMap.values()].filter((n) => n.topicId === topicId);
+  const nextOrder = siblings.length > 0 ? Math.max(...siblings.map((n) => n.customOrder)) + 1 : 0;
+
+  const note: Note = { id, title: '', body: '', topicId, createdAt: now, updatedAt: now, customOrder: nextOrder };
+
+  // Write plaintext to IndexedDB
+  const local: NoteLocal = {
+    id, userId, topicId, title: '', body: '', customOrder: nextOrder,
+    clientUpdatedAt: now, serverUpdatedAt: 0, isDeleted: false, version: 1, synced: false,
+  };
+  await idbSaveNote(local);
+  notesMap.set(id, note);
+
+  // Encrypt and queue for server
+  const { encryptedTitle, encryptedBody } = await encryptNote('', '', dek);
+  await queueNoteUpsert(id, userId, topicId, encryptedTitle, encryptedBody, nextOrder, now);
+  await tryServerUpsertNote(id, userId, topicId, encryptedTitle, encryptedBody, nextOrder, now);
+
+  return id;
+}
+
+/** Save (upsert) a note — encrypt → IndexedDB → server. */
+export async function saveNote(note: Note): Promise<void> {
+  const userId = auth.userId!;
+  const dek = auth.dek!;
+  const now = Date.now();
+  const updated = { ...note, updatedAt: now };
+
+  // Write plaintext to IndexedDB
+  const local: NoteLocal = {
+    id: note.id, userId, topicId: note.topicId,
+    title: note.title, body: note.body, customOrder: note.customOrder,
+    clientUpdatedAt: now, serverUpdatedAt: 0, isDeleted: false, version: 1, synced: false,
+  };
+  await idbSaveNote(local);
+  notesMap.set(note.id, updated);
+
+  // Encrypt and send to server
+  const { encryptedTitle, encryptedBody } = await encryptNote(note.title, note.body, dek);
+  await queueNoteUpsert(note.id, userId, note.topicId, encryptedTitle, encryptedBody, note.customOrder, now);
+  await tryServerUpsertNote(note.id, userId, note.topicId, encryptedTitle, encryptedBody, note.customOrder, now);
+}
+
+/** Soft-delete a note. */
+export async function deleteNote(id: string): Promise<void> {
+  notesMap.delete(id);
+  await idbMarkDeleted(id);
+
+  const item: SyncQueueItem = {
+    id, type: 'note', action: 'delete', payload: null, createdAt: Date.now(), retries: 0,
+  };
+  await enqueueSyncItem(item);
+
+  try {
+    const res = await apiFetch(`/api/notes/${id}`, { method: 'DELETE' });
+    if (res.ok) await dequeueSyncItem(id);
+  } catch {
+    // stays in queue
+  }
+}
+
+/** Reorder a note in custom sort mode. */
+export async function reorderNote(id: string, afterId: string | null): Promise<void> {
+  const note = notesMap.get(id);
+  if (!note) return;
+  const siblings = [...notesMap.values()]
+    .filter((n) => n.topicId === note.topicId && n.id !== id)
+    .sort((a, b) => a.customOrder - b.customOrder);
+  const insertIdx = afterId ? siblings.findIndex((n) => n.id === afterId) + 1 : 0;
+  siblings.splice(insertIdx, 0, { ...note });
+  // Update each sibling order
+  await Promise.all(
+    siblings.map(async (n, i) => {
+      const updated = { ...n, customOrder: i };
+      notesMap.set(n.id, updated);
+      const dek = auth.dek!;
+      const userId = auth.userId!;
+      const { encryptedTitle, encryptedBody } = await encryptNote(n.title, n.body, dek);
+      await idbSaveNote({ id: n.id, userId, topicId: n.topicId, title: n.title, body: n.body,
+        customOrder: i, clientUpdatedAt: n.updatedAt, serverUpdatedAt: 0, isDeleted: false, version: 1, synced: false });
+      await tryServerUpsertNote(n.id, userId, n.topicId, encryptedTitle, encryptedBody, i, n.updatedAt);
+    })
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Topic mutations
+// ---------------------------------------------------------------------------
+
+export async function createTopic(name: string, color: string, folderId: string | null = null): Promise<string> {
+  const id = crypto.randomUUID();
+  const userId = auth.userId!;
+  const siblings = getTopics().filter((t) => t.folderId === folderId);
+  const order = siblings.length > 0 ? Math.max(...siblings.map((t) => t.order)) + 1 : 0;
+
+  const topic: Topic = { id, name, color, folderId, order };
+  topicsMap.set(id, topic);
+
+  const local: TopicLocal = { id, userId, name, color, folderId, sortOrder: order, synced: false };
+  await idbSaveTopic(local);
+
+  const payload = { id, name, color, folderId, sortOrder: order };
+  await enqueueSyncItem({ id, type: 'topic', action: 'upsert', payload, createdAt: Date.now(), retries: 0 });
+  try {
+    const res = await apiFetch(`/api/topics/${id}`, { method: 'PUT', body: JSON.stringify(payload) });
+    if (res.ok) await dequeueSyncItem(id);
+  } catch { /* queue handles retry */ }
+
+  return id;
+}
+
+export async function saveTopic(topic: Topic): Promise<void> {
+  const userId = auth.userId!;
+  topicsMap.set(topic.id, topic);
+  await idbSaveTopic({ id: topic.id, userId, name: topic.name, color: topic.color,
+    folderId: topic.folderId, sortOrder: topic.order, synced: false });
+
+  const payload = { id: topic.id, name: topic.name, color: topic.color, folderId: topic.folderId, sortOrder: topic.order };
+  await enqueueSyncItem({ id: topic.id, type: 'topic', action: 'upsert', payload, createdAt: Date.now(), retries: 0 });
+  try {
+    const res = await apiFetch(`/api/topics/${topic.id}`, { method: 'PUT', body: JSON.stringify(payload) });
+    if (res.ok) await dequeueSyncItem(topic.id);
+  } catch { /* queue handles retry */ }
+}
+
+export async function deleteTopic(id: string): Promise<void> {
+  topicsMap.delete(id);
+  for (const [nid, note] of notesMap) {
+    if (note.topicId === id) notesMap.set(nid, { ...note, topicId: null });
+  }
+  await idbDeleteTopic(id);
+
+  await enqueueSyncItem({ id, type: 'topic', action: 'delete', payload: null, createdAt: Date.now(), retries: 0 });
+  try {
+    const res = await apiFetch(`/api/topics/${id}`, { method: 'DELETE' });
+    if (res.ok) await dequeueSyncItem(id);
+  } catch { /* queue handles retry */ }
+}
+
+export async function moveTopic(id: string, newFolderId: string | null, afterId?: string): Promise<void> {
+  const topic = topicsMap.get(id);
+  if (!topic) return;
+  const siblings = getTopics()
+    .filter((t) => t.folderId === newFolderId && t.id !== id)
+    .sort((a, b) => a.order - b.order);
+  const insertIdx = afterId ? siblings.findIndex((t) => t.id === afterId) + 1 : 0;
+  siblings.splice(insertIdx, 0, { ...topic, folderId: newFolderId });
+  await Promise.all(siblings.map((t, i) => saveTopic({ ...t, order: i })));
+}
+
+// ---------------------------------------------------------------------------
+// Folder mutations
+// ---------------------------------------------------------------------------
+
+export async function createFolder(name: string, parentId: string | null = null): Promise<string> {
+  const id = crypto.randomUUID();
+  const userId = auth.userId!;
+  const siblings = getFolders().filter((f) => f.parentId === parentId);
+  const order = siblings.length > 0 ? Math.max(...siblings.map((f) => f.order)) + 1 : 0;
+
+  const folder: Folder = { id, name, parentId, order, collapsed: false };
+  foldersMap.set(id, folder);
+
+  await idbSaveFolder({ id, userId, name, parentId, sortOrder: order, collapsed: false, synced: false });
+
+  const payload = { id, name, parentId, sortOrder: order, collapsed: false };
+  await enqueueSyncItem({ id, type: 'folder', action: 'upsert', payload, createdAt: Date.now(), retries: 0 });
+  try {
+    const res = await apiFetch(`/api/folders/${id}`, { method: 'PUT', body: JSON.stringify(payload) });
+    if (res.ok) await dequeueSyncItem(id);
+  } catch { /* queue handles retry */ }
+
+  return id;
+}
+
+export async function saveFolder(folder: Folder): Promise<void> {
+  const userId = auth.userId!;
+  foldersMap.set(folder.id, folder);
+  await idbSaveFolder({ id: folder.id, userId, name: folder.name, parentId: folder.parentId,
+    sortOrder: folder.order, collapsed: folder.collapsed, synced: false });
+
+  const payload = { id: folder.id, name: folder.name, parentId: folder.parentId,
+    sortOrder: folder.order, collapsed: folder.collapsed };
+  await enqueueSyncItem({ id: folder.id, type: 'folder', action: 'upsert', payload, createdAt: Date.now(), retries: 0 });
+  try {
+    const res = await apiFetch(`/api/folders/${folder.id}`, { method: 'PUT', body: JSON.stringify(payload) });
+    if (res.ok) await dequeueSyncItem(folder.id);
+  } catch { /* queue handles retry */ }
+}
+
+export function toggleFolderCollapsed(id: string): void {
+  const f = foldersMap.get(id);
+  if (f) saveFolder({ ...f, collapsed: !f.collapsed });
+}
+
+export async function deleteFolder(id: string): Promise<void> {
+  const folder = foldersMap.get(id);
+  if (!folder) return;
+  for (const [fid, f] of foldersMap) {
+    if (f.parentId === id) await saveFolder({ ...f, parentId: folder.parentId });
+  }
+  for (const [tid, t] of topicsMap) {
+    if (t.folderId === id) await saveTopic({ ...t, folderId: null });
+  }
+  foldersMap.delete(id);
+  await idbDeleteFolder(id);
+
+  await enqueueSyncItem({ id, type: 'folder', action: 'delete', payload: null, createdAt: Date.now(), retries: 0 });
+  try {
+    const res = await apiFetch(`/api/folders/${id}`, { method: 'DELETE' });
+    if (res.ok) await dequeueSyncItem(id);
+  } catch { /* queue handles retry */ }
+}
+
+export async function moveFolder(id: string, newParentId: string | null, afterId?: string): Promise<void> {
+  const folder = foldersMap.get(id);
+  if (!folder) return;
+  const siblings = getFolders()
+    .filter((f) => f.parentId === newParentId && f.id !== id)
+    .sort((a, b) => a.order - b.order);
+  const insertIdx = afterId ? siblings.findIndex((f) => f.id === afterId) + 1 : 0;
+  siblings.splice(insertIdx, 0, { ...folder, parentId: newParentId });
+  await Promise.all(siblings.map((f, i) => saveFolder({ ...f, order: i })));
+}
+
+// ---------------------------------------------------------------------------
+// Derived helpers (same API as before — UI components unchanged)
+// ---------------------------------------------------------------------------
+
 export function getFolders(): Folder[] {
-	return [...foldersMap.values()].sort((a, b) => a.order - b.order);
+  return [...foldersMap.values()].sort((a, b) => a.order - b.order);
 }
 
-/** All topics sorted by order within each folder group. */
 export function getTopics(): Topic[] {
-	return [...topicsMap.values()].sort((a, b) => a.order - b.order);
+  return [...topicsMap.values()].sort((a, b) => a.order - b.order);
 }
 
-/**
- * All notes, sorted by the active sort mode.
- *  - 'recent'  → newest updatedAt first (default)
- *  - 'alpha'   → title A→Z (case-insensitive)
- *  - 'custom'  → customOrder ascending within each topic group
- */
 export function getNotes(mode: SortMode = 'recent'): Note[] {
-	const all = [...notesMap.values()];
-	switch (mode) {
-		case 'alpha':
-			return all.sort((a, b) => a.title.localeCompare(b.title, undefined, { sensitivity: 'base' }));
-		case 'custom':
-			return all.sort((a, b) => a.customOrder - b.customOrder);
-		case 'recent':
-		default:
-			return all.sort((a, b) => b.updatedAt - a.updatedAt);
-	}
+  const all = [...notesMap.values()];
+  switch (mode) {
+    case 'alpha':
+      return all.sort((a, b) => a.title.localeCompare(b.title, undefined, { sensitivity: 'base' }));
+    case 'custom':
+      return all.sort((a, b) => a.customOrder - b.customOrder);
+    default:
+      return all.sort((a, b) => b.updatedAt - a.updatedAt);
+  }
 }
 
-/** Notes filtered by topic (null = uncategorised). */
 export function getNotesByTopic(topicId: string | null, mode: SortMode = 'recent'): Note[] {
-	return getNotes(mode).filter((n) => n.topicId === topicId);
+  return getNotes(mode).filter((n) => n.topicId === topicId);
 }
 
-/** Format a Unix ms timestamp as a human-readable relative string. */
 export function relativeTime(ms: number): string {
-	const diff = Date.now() - ms;
-	if (diff < 60_000)    return 'just now';
-	if (diff < 3600_000)  return `${Math.floor(diff / 60_000)}m ago`;
-	if (diff < 86400_000) return `${Math.floor(diff / 3600_000)}h ago`;
-	if (diff < 604800_000) return `${Math.floor(diff / 86400_000)}d ago`;
-	return new Date(ms).toLocaleDateString();
+  const diff = Date.now() - ms;
+  if (diff < 60_000) return 'just now';
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  if (diff < 604_800_000) return `${Math.floor(diff / 86_400_000)}d ago`;
+  return new Date(ms).toLocaleDateString();
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function localToNote(n: NoteLocal): Note {
+  return {
+    id: n.id, title: n.title, body: n.body, topicId: n.topicId,
+    createdAt: n.clientUpdatedAt, updatedAt: n.clientUpdatedAt, customOrder: n.customOrder,
+  };
+}
+
+function localToTopic(t: TopicLocal): Topic {
+  return { id: t.id, name: t.name, color: t.color, folderId: t.folderId, order: t.sortOrder };
+}
+
+function localToFolder(f: FolderLocal): Folder {
+  return { id: f.id, name: f.name, parentId: f.parentId, order: f.sortOrder, collapsed: f.collapsed };
+}
+
+async function queueNoteUpsert(
+  id: string, userId: string, topicId: string | null,
+  encryptedTitle: string, encryptedBody: string,
+  customOrder: number, clientUpdatedAt: number
+): Promise<void> {
+  const payload = {
+    id, topicId, encryptedTitle, encryptedBody, customOrder,
+    clientUpdatedAt: new Date(clientUpdatedAt).toISOString(),
+  };
+  await enqueueSyncItem({ id, type: 'note', action: 'upsert', payload, createdAt: Date.now(), retries: 0 });
+}
+
+async function tryServerUpsertNote(
+  id: string, userId: string, topicId: string | null,
+  encryptedTitle: string, encryptedBody: string,
+  customOrder: number, clientUpdatedAt: number
+): Promise<void> {
+  try {
+    const payload = {
+      id, topicId, encryptedTitle, encryptedBody, customOrder,
+      clientUpdatedAt: new Date(clientUpdatedAt).toISOString(),
+    };
+    const res = await apiFetch(`/api/notes/${id}`, { method: 'PUT', body: JSON.stringify(payload) });
+    if (res.ok) {
+      await dequeueSyncItem(id);
+      const n = notesMap.get(id);
+      if (n) {
+        await idbSaveNote({
+          id, userId, topicId, title: n.title, body: n.body, customOrder,
+          clientUpdatedAt, serverUpdatedAt: Date.now(), isDeleted: false, version: 1, synced: true,
+        });
+      }
+    }
+  } catch {
+    // Offline — item stays in queue
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Server response types (internal — not exported)
+// ---------------------------------------------------------------------------
+
+interface ServerNote {
+  id: string;
+  topic_id: string | null;
+  encrypted_title: string;
+  encrypted_body: string;
+  custom_order: number;
+  client_updated_at: string;
+  server_updated_at: string;
+  is_deleted: boolean;
+  version: number;
+}
+
+interface ServerTopic {
+  id: string;
+  name: string;
+  color: string;
+  folder_id: string | null;
+  sort_order: number;
+}
+
+interface ServerFolder {
+  id: string;
+  name: string;
+  parent_id: string | null;
+  sort_order: number;
+  collapsed: boolean;
 }

--- a/bedroc/src/routes/+layout.svelte
+++ b/bedroc/src/routes/+layout.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import '../app.css';
 	import { page } from '$app/state';
+	import { goto } from '$app/navigation';
+	import { onMount } from 'svelte';
+	import { auth, restoreSession } from '$lib/stores/auth.svelte.js';
 
 	let { children } = $props();
 
@@ -12,6 +15,18 @@
 	// Note editor owns its full-width toolbar on mobile, so we hide the global
 	// mobile header on that route to avoid doubling up.
 	let isNoteRoute = $derived(path.startsWith('/note'));
+
+	// ── Auth guard ────────────────────────────────────────────────
+	// On mount, try to restore session from httpOnly refresh cookie.
+	// If that fails (or DEK is missing), redirect to /login.
+	// isAuthRoute pages (login/register) skip the guard.
+	onMount(async () => {
+		if (isAuthRoute) return;
+		await restoreSession();
+		if (!auth.isLoggedIn) {
+			goto('/login');
+		}
+	});
 
 	const navItems = [
 		{ href: '/',         label: 'Notes',    icon: 'notes' },

--- a/bedroc/src/routes/+page.svelte
+++ b/bedroc/src/routes/+page.svelte
@@ -11,6 +11,7 @@
 		type Topic, type Folder, type Note, type SortMode
 	} from '$lib/stores/notes.svelte';
 	import { goto } from '$app/navigation';
+	import { serverStatus } from '$lib/stores/auth.svelte.js';
 
 	// ── Filter / navigation state ──────────────────────────────────
 	let search        = $state('');
@@ -625,6 +626,15 @@
                             </svg>
                         </button>
                     </div>
+                    <!-- Server status dot -->
+                    {#if serverStatus.value !== 'unknown'}
+                        <span
+                            class="srv-dot srv-dot-{serverStatus.value}"
+                            title={serverStatus.value === 'online' ? 'Server online' : serverStatus.value === 'checking' ? 'Checking server…' : 'Server unreachable'}
+                            aria-label={serverStatus.value === 'online' ? 'Server online' : 'Server unreachable'}
+                        ></span>
+                    {/if}
+
                     <button class="new-btn" onclick={handleNewNote} aria-label="New note">
                         <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
                             <path d="M6.5 1v11M1 6.5h11" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
@@ -1203,6 +1213,23 @@
     }
 
 	.notes-title { font-size: 16px; font-weight: 600; }
+
+	/* Server status dot in notes header */
+	.srv-dot {
+		width: 7px;
+		height: 7px;
+		border-radius: 50%;
+		flex-shrink: 0;
+		display: inline-block;
+	}
+	.srv-dot-checking { background: var(--accent); animation: srv-pulse 1s ease-in-out infinite; }
+	.srv-dot-online   { background: var(--success); }
+	.srv-dot-offline  { background: var(--danger); }
+
+	@keyframes srv-pulse {
+		0%, 100% { opacity: 1; }
+		50%       { opacity: 0.3; }
+	}
 
 	.notes-header-actions {
 		display: flex;

--- a/bedroc/src/routes/login/+page.svelte
+++ b/bedroc/src/routes/login/+page.svelte
@@ -1,30 +1,61 @@
 <script lang="ts">
-	// Default public server — users change this to their own backend URL.
-	// The value is persisted to localStorage so it survives page reloads.
-	let serverUrl = $state(
-		typeof localStorage !== 'undefined'
-			? (localStorage.getItem('bedroc_server') ?? 'https://api.bedroc.app')
-			: 'https://api.bedroc.app'
-	);
+	import { goto } from '$app/navigation';
+	import {
+		auth, login, setServerUrl, removeSavedServer,
+		normaliseServerUrl, checkServerHealth, serverStatus,
+	} from '$lib/stores/auth.svelte.js';
+	import { loadFromDb, syncFromServer } from '$lib/stores/notes.svelte.js';
 
 	let serverExpanded = $state(false);
 	let showPassword = $state(false);
 	let username = $state('');
 	let password = $state('');
+	let newServerInput = $state(auth.serverUrl);
 
-	function toggleServer() {
-		serverExpanded = !serverExpanded;
-	}
+	// Local client-side validation errors; combined with store errors
+	let localError = $state<string | null>(null);
+	let displayError = $derived(localError ?? auth.error);
 
-	function saveServer() {
-		localStorage.setItem('bedroc_server', serverUrl);
-		serverExpanded = false;
-	}
-
-	function handleSubmit(e: Event) {
+	async function handleSubmit(e: Event) {
 		e.preventDefault();
-		// Auth logic wired in Phase 1 — placeholder for now.
+		localError = null;
+		if (!username.trim()) { localError = 'Please enter your username.'; return; }
+		if (!password) { localError = 'Please enter your password.'; return; }
+		try {
+			await login(username.trim(), password);
+			await loadFromDb();
+			syncFromServer(); // fire-and-forget background sync
+			goto('/');
+		} catch {
+			// error already set in auth.error by the store
+		}
 	}
+
+	async function saveServer() {
+		const url = normaliseServerUrl(newServerInput.trim());
+		newServerInput = url; // show normalised form
+		setServerUrl(url);
+		serverExpanded = false;
+		await checkServerHealth(url);
+	}
+
+	function selectServer(url: string) {
+		setServerUrl(url);
+		newServerInput = url;
+		serverExpanded = false;
+		checkServerHealth(url);
+	}
+
+	// Run health check whenever server panel opens
+	$effect(() => { if (serverExpanded) checkServerHealth(); });
+
+	const statusDot: Record<string, string> = {
+		unknown: 'dot-unknown', checking: 'dot-checking',
+		online:  'dot-online',  offline:  'dot-offline',
+	};
+	const statusLabel: Record<string, string> = {
+		unknown: '', checking: 'Checking…', online: 'Online', offline: 'Unreachable',
+	};
 </script>
 
 <svelte:head>
@@ -39,6 +70,10 @@
 	</div>
 
 	<form class="form" onsubmit={handleSubmit}>
+		{#if displayError}
+			<div class="error-banner" role="alert">{displayError}</div>
+		{/if}
+
 		<div class="field">
 			<label for="username" class="field-label">Username</label>
 			<input
@@ -50,6 +85,7 @@
 				spellcheck="false"
 				placeholder="your username"
 				bind:value={username}
+				disabled={auth.loading}
 				required
 			/>
 		</div>
@@ -63,6 +99,7 @@
 					autocomplete="current-password"
 					placeholder="••••••••••••"
 					bind:value={password}
+					disabled={auth.loading}
 					required
 				/>
 				<button
@@ -87,9 +124,9 @@
 
 		<!-- Server URL — subtle, expandable -->
 		<div class="server-row">
-			<button type="button" class="server-toggle" onclick={toggleServer}>
+			<button type="button" class="server-toggle" onclick={() => (serverExpanded = !serverExpanded)}>
 				<span class="server-label">Server</span>
-				<span class="server-url">{serverUrl}</span>
+				<span class="server-url">{auth.serverUrl}</span>
 				<svg
 					width="12"
 					height="12"
@@ -104,11 +141,12 @@
 
 			{#if serverExpanded}
 				<div class="server-input-wrap">
+					<!-- type="text" so bare IPs (10.66.66.1) are accepted without browser validation errors -->
 					<input
-						type="url"
+						type="text"
 						class="server-input"
-						placeholder="https://api.bedroc.app"
-						bind:value={serverUrl}
+						placeholder="https://api.bedroc.app or 10.66.66.1"
+						bind:value={newServerInput}
 						spellcheck="false"
 						autocorrect="off"
 						autocapitalize="off"
@@ -117,13 +155,53 @@
 						Save
 					</button>
 				</div>
+
+				<!-- Live health check indicator -->
+				{#if serverStatus.value !== 'unknown'}
+					<div class="server-status">
+						<span class="status-dot {statusDot[serverStatus.value]}"></span>
+						<span class="status-text" class:status-offline={serverStatus.value === 'offline'}>
+							{statusLabel[serverStatus.value]}
+						</span>
+						{#if serverStatus.value === 'offline'}
+							<span class="status-help">— Check the URL and make sure the server is running</span>
+						{/if}
+					</div>
+				{/if}
+
+				{#if auth.savedServers.length > 1}
+					<div class="saved-servers">
+						{#each auth.savedServers as url}
+							<div class="saved-server-row">
+								<button type="button" class="saved-server-btn" onclick={() => selectServer(url)}>
+									{url}
+								</button>
+								{#if url !== 'https://api.bedroc.app'}
+									<button
+										type="button"
+										class="btn-icon remove-server"
+										onclick={() => removeSavedServer(url)}
+										aria-label="Remove server"
+									>
+										<svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+											<path d="M2 2l8 8M10 2L2 10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+										</svg>
+									</button>
+								{/if}
+							</div>
+						{/each}
+					</div>
+				{/if}
+
 				<p class="server-hint">
-					Enter your self-hosted backend URL, or leave as default to use bedroc.app.
+					Enter any format: <code>10.66.66.1</code>, <code>192.168.1.5:3000</code>, or <code>https://notes.example.com</code>. Plain IPs default to http://, domain names to https://.
 				</p>
 			{/if}
 		</div>
 
-		<button type="submit" class="btn-primary">Log in</button>
+		<button type="submit" class="btn-primary" disabled={auth.loading}>
+			{auth.loading ? 'Logging in…' : 'Log in'}
+		</button>
 	</form>
 
 	<p class="auth-switch">
@@ -167,6 +245,16 @@
 	.brand-tagline {
 		font-size: 13px;
 		color: var(--text-muted);
+	}
+
+	/* Error banner */
+	.error-banner {
+		background: color-mix(in srgb, var(--danger) 12%, transparent);
+		border: 1px solid color-mix(in srgb, var(--danger) 30%, transparent);
+		border-radius: var(--radius-md);
+		padding: 10px 12px;
+		font-size: 13px;
+		color: var(--danger);
 	}
 
 	/* Form */
@@ -269,11 +357,91 @@
 		white-space: nowrap;
 	}
 
+	.saved-servers {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		background: var(--bg-elevated);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-md);
+		overflow: hidden;
+	}
+
+	.saved-server-row {
+		display: flex;
+		align-items: center;
+	}
+
+	.saved-server-btn {
+		flex: 1;
+		text-align: left;
+		background: none;
+		border: none;
+		padding: 8px 10px;
+		font-size: 12px;
+		color: var(--text-muted);
+		cursor: pointer;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.saved-server-btn:hover {
+		background: var(--bg-hover);
+		color: var(--text);
+	}
+
+	.remove-server {
+		padding: 8px;
+		color: var(--text-faint);
+	}
+
+	.remove-server:hover {
+		color: var(--danger);
+	}
+
 	.server-hint {
 		font-size: 11px;
 		color: var(--text-faint);
-		line-height: 1.5;
+		line-height: 1.6;
 	}
+
+	.server-hint code {
+		font-family: monospace;
+		font-size: 11px;
+		background: var(--bg-hover);
+		padding: 1px 4px;
+		border-radius: 3px;
+	}
+
+	/* Health check status */
+	.server-status {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		font-size: 12px;
+	}
+
+	.status-dot {
+		width: 7px;
+		height: 7px;
+		border-radius: 50%;
+		flex-shrink: 0;
+	}
+
+	.dot-unknown  { background: var(--text-faint); }
+	.dot-checking { background: var(--text-faint); animation: pulse 1s infinite; }
+	.dot-online   { background: var(--success); }
+	.dot-offline  { background: var(--danger); }
+
+	@keyframes pulse {
+		0%, 100% { opacity: 1; }
+		50%       { opacity: 0.3; }
+	}
+
+	.status-text { color: var(--text-muted); }
+	.status-text.status-offline { color: var(--danger); }
+	.status-help { color: var(--text-faint); font-size: 11px; }
 
 	/* Bottom link */
 	.auth-switch {

--- a/bedroc/src/routes/note/[id]/+page.svelte
+++ b/bedroc/src/routes/note/[id]/+page.svelte
@@ -17,7 +17,7 @@
 	let isNew   = $derived(noteId === 'new');
 
 	// ── Load note ─────────────────────────────────────────────────
-	// PLACEHOLDER: no decryption — Phase 2 will AES-GCM decrypt the body.
+	// Notes are stored decrypted in IndexedDB; encryption happens at sync time.
 	let title = $state('');
 	let saved = $state(true);
 	let bodyEl: HTMLDivElement;
@@ -37,7 +37,6 @@
 	});
 
 	// ── Autosave ──────────────────────────────────────────────────
-	// PLACEHOLDER: saves to in-memory store only.
 	import { autosave } from '$lib/stores/notes.svelte';
 
 	let autosaveTimer: ReturnType<typeof setTimeout> | null = null;
@@ -48,19 +47,19 @@
 		autosaveTimer = setTimeout(doSave, autosave.interval);
 	}
 
-	function doSave() {
+	async function doSave() {
 		if (saved) return;
 		const body = bodyEl?.innerHTML ?? '';
 		if (isNew) {
-			const id = createNote(null);
+			const id = await createNote(null);
 			const created = notesMap.get(id)!;
-			saveNote({ ...created, title: dedupTitle(title.trim() || 'Untitled', null, id), body });
+			await saveNote({ ...created, title: dedupTitle(title.trim() || 'Untitled', null, id), body });
 			saved = true;
 			goto(`/note/${id}`, { replaceState: true });
 		} else {
 			const existing = notesMap.get(noteId!);
 			if (!existing) return;
-			saveNote({ ...existing, title: dedupTitle(title.trim() || 'Untitled', existing.topicId, existing.id), body });
+			await saveNote({ ...existing, title: dedupTitle(title.trim() || 'Untitled', existing.topicId, existing.id), body });
 			saved = true;
 		}
 	}
@@ -91,22 +90,21 @@
 	function handleTitleInput() { saved = false; scheduleAutosave(); }
 	function handleBodyInput()  { saved = false; scheduleAutosave(); updateFormatState(); }
 
-	function handleSave() {
+	async function handleSave() {
 		if (autosaveTimer) { clearTimeout(autosaveTimer); autosaveTimer = null; }
-		doSave();
+		await doSave();
 	}
 
-	function handleBack() {
-		if (!saved) doSave();
+	async function handleBack() {
+		if (!saved) await doSave();
 		goto('/');
 	}
 
-	function handleDelete() {
+	async function handleDelete() {
 		if (isNew) { goto('/'); return; }
-		import('$lib/stores/notes.svelte').then(({ deleteNote }) => {
-			deleteNote(noteId!);
-			goto('/');
-		});
+		const { deleteNote } = await import('$lib/stores/notes.svelte');
+		await deleteNote(noteId!);
+		goto('/');
 	}
 
 	// ── Rich text commands ────────────────────────────────────────

--- a/bedroc/src/routes/register/+page.svelte
+++ b/bedroc/src/routes/register/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-	let serverUrl = $state(
-		typeof localStorage !== 'undefined'
-			? (localStorage.getItem('bedroc_server') ?? 'https://api.bedroc.app')
-			: 'https://api.bedroc.app'
-	);
+	import { goto } from '$app/navigation';
+	import {
+		auth, register, setServerUrl,
+		normaliseServerUrl, checkServerHealth, serverStatus,
+	} from '$lib/stores/auth.svelte.js';
+	import { loadFromDb } from '$lib/stores/notes.svelte.js';
 
 	let serverExpanded = $state(false);
 	let showPassword = $state(false);
@@ -11,9 +12,12 @@
 	let username = $state('');
 	let password = $state('');
 	let confirm = $state('');
+	let newServerInput = $state(auth.serverUrl);
 
-	// Naive strength score 0–4 used to render the strength bar.
-	// Will be replaced by zxcvbn in Phase 1.
+	let localError = $state<string | null>(null);
+	let displayError = $derived(localError ?? auth.error);
+
+	// Password strength 0–4
 	let strength = $derived((() => {
 		if (password.length === 0) return 0;
 		let score = 0;
@@ -27,17 +31,47 @@
 	const strengthLabels = ['', 'Weak', 'Fair', 'Good', 'Strong'];
 	const strengthColors = ['', '#e05c5c', '#e0a45c', '#6b8afd', '#4caf87'];
 
+	let passwordTooWeak = $derived(password.length > 0 && strength < 2);
 	let passwordsMatch = $derived(confirm.length > 0 && password === confirm);
 	let passwordMismatch = $derived(confirm.length > 0 && password !== confirm);
+	let submitDisabled = $derived(auth.loading || (confirm.length > 0 && passwordMismatch) || passwordTooWeak);
 
-	function saveServer() {
-		localStorage.setItem('bedroc_server', serverUrl);
+	async function saveServer() {
+		const url = normaliseServerUrl(newServerInput.trim());
+		newServerInput = url;
+		setServerUrl(url);
 		serverExpanded = false;
+		await checkServerHealth(url);
 	}
 
-	function handleSubmit(e: Event) {
+	$effect(() => { if (serverExpanded) checkServerHealth(); });
+
+	const statusDot: Record<string, string> = {
+		unknown: 'dot-unknown', checking: 'dot-checking',
+		online:  'dot-online',  offline:  'dot-offline',
+	};
+	const statusLabel: Record<string, string> = {
+		unknown: '', checking: 'Checking…', online: 'Online', offline: 'Unreachable',
+	};
+
+	async function handleSubmit(e: Event) {
 		e.preventDefault();
-		// Auth logic wired in Phase 1 — placeholder for now.
+		localError = null;
+
+		if (!username.trim()) { localError = 'Please choose a username.'; return; }
+		if (username.trim().length < 3) { localError = 'Username must be at least 3 characters.'; return; }
+		if (/\s/.test(username.trim())) { localError = 'Username cannot contain spaces.'; return; }
+		if (password.length < 8) { localError = 'Password must be at least 8 characters.'; return; }
+		if (strength < 2) { localError = 'Password is too weak. Add uppercase letters, numbers, or symbols.'; return; }
+		if (password !== confirm) { localError = 'Passwords do not match.'; return; }
+
+		try {
+			await register(username.trim(), password);
+			await loadFromDb();
+			goto('/');
+		} catch {
+			// error already set in auth.error
+		}
 	}
 </script>
 
@@ -53,6 +87,10 @@
 	</div>
 
 	<form class="form" onsubmit={handleSubmit}>
+		{#if displayError}
+			<div class="error-banner" role="alert">{displayError}</div>
+		{/if}
+
 		<div class="field">
 			<label for="username" class="field-label">Username</label>
 			<input
@@ -64,6 +102,7 @@
 				spellcheck="false"
 				placeholder="choose a username"
 				bind:value={username}
+				disabled={auth.loading}
 				required
 			/>
 		</div>
@@ -77,6 +116,7 @@
 					autocomplete="new-password"
 					placeholder="••••••••••••"
 					bind:value={password}
+					disabled={auth.loading}
 					required
 				/>
 				<button
@@ -96,7 +136,6 @@
 				</button>
 			</div>
 
-			<!-- Strength bar -->
 			{#if password.length > 0}
 				<div class="strength-bar-wrap">
 					<div class="strength-bar">
@@ -111,6 +150,9 @@
 						{strengthLabels[strength]}
 					</span>
 				</div>
+				{#if passwordTooWeak}
+					<p class="field-warning">Use at least 8 characters with uppercase, numbers, or symbols.</p>
+				{/if}
 			{/if}
 		</div>
 
@@ -123,6 +165,7 @@
 					autocomplete="new-password"
 					placeholder="••••••••••••"
 					bind:value={confirm}
+					disabled={auth.loading}
 					class:input-error={passwordMismatch}
 					class:input-ok={passwordsMatch}
 					required
@@ -152,17 +195,28 @@
 		<div class="server-row">
 			<button type="button" class="server-toggle" onclick={() => (serverExpanded = !serverExpanded)}>
 				<span class="server-label">Server</span>
-				<span class="server-url">{serverUrl}</span>
+				<span class="server-url">{auth.serverUrl}</span>
 				<svg width="12" height="12" viewBox="0 0 12 12" fill="none" class="chevron" class:rotated={serverExpanded}>
 					<path d="M2 4l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 				</svg>
 			</button>
 			{#if serverExpanded}
 				<div class="server-input-wrap">
-					<input type="url" class="server-input" placeholder="https://api.bedroc.app" bind:value={serverUrl} spellcheck="false" autocorrect="off" autocapitalize="off"/>
+					<input type="text" class="server-input" placeholder="https://api.bedroc.app or 10.66.66.1" bind:value={newServerInput} spellcheck="false" autocorrect="off" autocapitalize="off"/>
 					<button type="button" class="btn-ghost server-save" onclick={saveServer}>Save</button>
 				</div>
-				<p class="server-hint">Enter your self-hosted backend URL, or leave as default to use bedroc.app.</p>
+				{#if serverStatus.value !== 'unknown'}
+					<div class="server-status">
+						<span class="status-dot {statusDot[serverStatus.value]}"></span>
+						<span class="status-text" class:status-offline={serverStatus.value === 'offline'}>
+							{statusLabel[serverStatus.value]}
+						</span>
+						{#if serverStatus.value === 'offline'}
+							<span class="status-help">— Check the URL and make sure the server is running</span>
+						{/if}
+					</div>
+				{/if}
+				<p class="server-hint">Enter any format: <code>10.66.66.1</code>, <code>192.168.1.5:3000</code>, or <code>https://notes.example.com</code>. Plain IPs default to http://, domain names to https://.</p>
 			{/if}
 		</div>
 
@@ -175,7 +229,9 @@
 			<span>Your notes are encrypted with your password before leaving your device. <strong>If you lose your password, your data cannot be recovered.</strong> Use a password manager.</span>
 		</div>
 
-		<button type="submit" class="btn-primary">Create account</button>
+		<button type="submit" class="btn-primary" disabled={submitDisabled}>
+			{auth.loading ? 'Creating account…' : 'Create account'}
+		</button>
 	</form>
 
 	<p class="auth-switch">
@@ -219,6 +275,15 @@
 		color: var(--text-muted);
 	}
 
+	.error-banner {
+		background: color-mix(in srgb, var(--danger) 12%, transparent);
+		border: 1px solid color-mix(in srgb, var(--danger) 30%, transparent);
+		border-radius: var(--radius-md);
+		padding: 10px 12px;
+		font-size: 13px;
+		color: var(--danger);
+	}
+
 	.form {
 		display: flex;
 		flex-direction: column;
@@ -240,6 +305,46 @@
 	.field-error {
 		font-size: 11px;
 		color: var(--danger);
+	}
+
+	.field-warning {
+		font-size: 11px;
+		color: var(--text-muted);
+	}
+
+	.server-status {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		font-size: 12px;
+	}
+
+	.status-dot {
+		width: 7px;
+		height: 7px;
+		border-radius: 50%;
+		flex-shrink: 0;
+	}
+
+	.dot-unknown  { background: var(--text-faint); }
+	.dot-checking { background: var(--accent); animation: pulse 1s ease-in-out infinite; }
+	.dot-online   { background: var(--success); }
+	.dot-offline  { background: var(--danger); }
+
+	@keyframes pulse {
+		0%, 100% { opacity: 1; }
+		50%       { opacity: 0.3; }
+	}
+
+	.status-text    { color: var(--text-muted); }
+	.status-offline { color: var(--danger); }
+	.status-help    { color: var(--text-faint); font-size: 11px; }
+
+	.server-hint code {
+		font-family: monospace;
+		background: var(--bg-hover);
+		padding: 1px 4px;
+		border-radius: 3px;
 	}
 
 	.input-wrap {
@@ -265,7 +370,6 @@
 		border-color: var(--success) !important;
 	}
 
-	/* Strength bar */
 	.strength-bar-wrap {
 		display: flex;
 		align-items: center;
@@ -292,7 +396,6 @@
 		transition: color 0.2s ease;
 	}
 
-	/* Server row — same as login */
 	.server-row {
 		display: flex;
 		flex-direction: column;
@@ -363,7 +466,6 @@
 		line-height: 1.5;
 	}
 
-	/* E2EE notice */
 	.notice {
 		display: flex;
 		gap: 8px;

--- a/bedroc/src/routes/settings/+page.svelte
+++ b/bedroc/src/routes/settings/+page.svelte
@@ -1,20 +1,55 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
 	import { autosave } from '$lib/stores/notes.svelte';
+	import { auth, logout, apiFetch } from '$lib/stores/auth.svelte.js';
+	import { clearStore } from '$lib/stores/notes.svelte.js';
 
-	// Settings page — shell only. Actual logic wired in Phase 5/6.
 	let confirmLogout = $state(false);
 	let confirmDelete = $state(false);
 
-	const serverUrl =
-		typeof localStorage !== 'undefined'
-			? (localStorage.getItem('bedroc_server') ?? 'https://api.bedroc.app')
-			: 'https://api.bedroc.app';
+	// ── Sessions ──────────────────────────────────────────────────
+	interface Session {
+		id: string;
+		device_info: string | null;
+		created_at: string;
+		expires_at: string;
+	}
 
-	// Placeholder session list — real data from server in Phase 5.
-	const sessions = [
-		{ id: '1', device: 'Chrome on macOS',  location: 'Current session', current: true },
-		{ id: '2', device: 'Safari on iPhone', location: 'Last seen 2h ago', current: false },
-	];
+	let sessions = $state<Session[]>([]);
+	let sessionsLoading = $state(true);
+
+	async function loadSessions() {
+		try {
+			const res = await apiFetch('/api/auth/sessions');
+			if (res.ok) sessions = await res.json() as Session[];
+		} catch { /* offline — no sessions list */ }
+		sessionsLoading = false;
+	}
+
+	// Load on mount
+	$effect(() => { loadSessions(); });
+
+	async function revokeSession(id: string) {
+		try {
+			await apiFetch(`/api/auth/sessions/${id}`, { method: 'DELETE' });
+			sessions = sessions.filter(s => s.id !== id);
+		} catch { /* ignore */ }
+	}
+
+	async function handleLogout() {
+		clearStore();
+		await logout();
+		goto('/login');
+	}
+
+	async function handleDeleteAccount() {
+		try {
+			await apiFetch('/api/auth/account', { method: 'DELETE' });
+		} catch { /* ignore */ }
+		clearStore();
+		await logout();
+		goto('/login');
+	}
 
 	// ── Autosave settings ─────────────────────────────────────────
 	// autosave.interval === 0 means disabled.
@@ -47,14 +82,14 @@
 			<div class="row">
 				<div class="row-info">
 					<span class="row-label">Username</span>
-					<span class="row-value">username</span>
+					<span class="row-value">{auth.username ?? '—'}</span>
 				</div>
 			</div>
 			<div class="divider-inner"></div>
 			<div class="row">
 				<div class="row-info">
 					<span class="row-label">Server</span>
-					<span class="row-value muted">{serverUrl}</span>
+					<span class="row-value muted">{auth.serverUrl}</span>
 				</div>
 			</div>
 		</div>
@@ -138,23 +173,28 @@
 	<section class="section">
 		<h3 class="section-title">Active sessions</h3>
 		<div class="card">
-			{#each sessions as session, i (session.id)}
-				{#if i > 0}<div class="divider-inner"></div>{/if}
-				<div class="row">
-					<div class="row-info">
-						<span class="row-label">
-							{session.device}
-							{#if session.current}
-								<span class="badge">This device</span>
-							{/if}
-						</span>
-						<span class="row-sub">{session.location}</span>
+			{#if sessionsLoading}
+				<div class="row"><span class="row-sub">Loading…</span></div>
+			{:else if sessions.length === 0}
+				<div class="row"><span class="row-sub">No sessions found.</span></div>
+			{:else}
+				{#each sessions as session, i (session.id)}
+					{#if i > 0}<div class="divider-inner"></div>{/if}
+					<div class="row">
+						<div class="row-info">
+							<span class="row-label">
+								{session.device_info ?? 'Unknown device'}
+							</span>
+							<span class="row-sub">
+								Active until {new Date(session.expires_at).toLocaleDateString()}
+							</span>
+						</div>
+						<button class="btn-ghost revoke-btn" onclick={() => revokeSession(session.id)}>
+							Revoke
+						</button>
 					</div>
-					{#if !session.current}
-						<button class="btn-ghost revoke-btn">Revoke</button>
-					{/if}
-				</div>
-			{/each}
+				{/each}
+			{/if}
 		</div>
 	</section>
 
@@ -175,7 +215,7 @@
 				{:else}
 					<div class="confirm-row">
 						<span class="confirm-text">Sure?</span>
-						<button class="btn-danger confirm-yes">Yes, log out</button>
+						<button class="btn-danger confirm-yes" onclick={handleLogout}>Yes, log out</button>
 						<button class="btn-ghost" onclick={() => (confirmLogout = false)}>Cancel</button>
 					</div>
 				{/if}
@@ -194,7 +234,7 @@
 				{:else}
 					<div class="confirm-row">
 						<span class="confirm-text">Sure?</span>
-						<button class="btn-danger confirm-yes">Delete forever</button>
+						<button class="btn-danger confirm-yes" onclick={handleDeleteAccount}>Delete forever</button>
 						<button class="btn-ghost" onclick={() => (confirmDelete = false)}>Cancel</button>
 					</div>
 				{/if}

--- a/bedroc/svelte.config.js
+++ b/bedroc/svelte.config.js
@@ -1,12 +1,14 @@
-import adapter from '@sveltejs/adapter-auto';
+import adapter from '@sveltejs/adapter-static';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
-		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
-		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
-		adapter: adapter()
+		// adapter-static: outputs a fully prerendered SPA to the build/ directory.
+		// nginx in the bedroc container serves these static files.
+		// The fallback option enables client-side routing (all paths → index.html).
+		adapter: adapter({
+			fallback: 'index.html',
+		}),
 	}
 };
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,194 @@
+# =============================================================================
+# docker-compose.yml — Bedroc production stack
+# =============================================================================
+#
+# Services:
+#   postgres   — PostgreSQL 16 (encrypted note storage)
+#   redis      — Redis 7 (rate limiting, SRP challenge storage)
+#   server     — Fastify backend (Node.js 22)
+#   bedroc     — SvelteKit frontend (nginx static)
+#   nginx      — Reverse proxy (TLS termination, WireGuard-only binding)
+#
+# Usage:
+#   cp .env.example .env
+#   # Fill in all values in .env (generate secrets with: openssl rand -hex 32)
+#   docker compose up -d
+#
+# WireGuard-only access:
+#   nginx binds ONLY to 10.66.66.1 (the WireGuard VPN interface).
+#   No ports are exposed on the public internet.
+#   Connect to WireGuard first, then browse to https://10.66.66.1
+#
+# SSL certificates:
+#   Mount your certs at docker/ssl/ before first boot:
+#     docker/ssl/cert.pem  — full chain PEM
+#     docker/ssl/key.pem   — private key PEM
+#   Generate self-signed (works fine with WireGuard):
+#     mkdir -p docker/ssl
+#     openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes \
+#       -keyout docker/ssl/key.pem -out docker/ssl/cert.pem \
+#       -subj "/CN=bedroc" -addext "subjectAltName=IP:10.66.66.1"
+# =============================================================================
+
+services:
+
+  # ── PostgreSQL 16 ───────────────────────────────────────────────────────────
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+
+    environment:
+      POSTGRES_DB: bedroc
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+
+    volumes:
+      # Persistent data volume — survives container restarts and rebuilds
+      - postgres_data:/var/lib/postgresql/data
+      # First-boot init script: creates bedroc_app user with least-privilege access
+      - ./docker/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+
+    networks:
+      - internal
+
+    # Postgres is NOT exposed on any host port — internal Docker network only.
+    # The server container connects via the 'internal' network.
+
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d bedroc"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  # ── Redis 7 ─────────────────────────────────────────────────────────────────
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+
+    # Require a password even on internal network (defence in depth)
+    # If you set this, update REDIS_URL to: redis://:PASSWORD@redis:6379
+    command: redis-server --save 60 1 --loglevel warning
+
+    volumes:
+      - redis_data:/data
+
+    networks:
+      - internal
+
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+
+  # ── Fastify backend ──────────────────────────────────────────────────────────
+  server:
+    build:
+      context: ./server
+      dockerfile: Dockerfile
+
+    restart: unless-stopped
+
+    environment:
+      HOST: 0.0.0.0         # Listen on all interfaces inside Docker network
+      PORT: 3000
+      NODE_ENV: production
+      DATABASE_URL: ${DATABASE_URL}
+      REDIS_URL: ${REDIS_URL}
+      JWT_ACCESS_SECRET: ${JWT_ACCESS_SECRET}
+      JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET}
+      JWT_ACCESS_EXPIRY: ${JWT_ACCESS_EXPIRY:-15m}
+      JWT_REFRESH_EXPIRY: ${JWT_REFRESH_EXPIRY:-7d}
+      CORS_ORIGIN: ${CORS_ORIGIN}
+
+    networks:
+      - internal
+
+    # Server is NOT exposed on any host port — nginx proxies to it internally.
+
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+  # ── SvelteKit frontend ───────────────────────────────────────────────────────
+  bedroc:
+    build:
+      context: ./bedroc
+      dockerfile: Dockerfile
+
+    restart: unless-stopped
+
+    networks:
+      - internal
+
+    # Not exposed on host — nginx proxies to it.
+
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/ || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+
+  # ── nginx (TLS + WireGuard binding) ─────────────────────────────────────────
+  nginx:
+    image: nginx:1.27-alpine
+    restart: unless-stopped
+
+    volumes:
+      # Main nginx config — binds ONLY to 10.66.66.1
+      - ./docker/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      # TLS certificates — generate before first boot (see header comment)
+      - ./docker/ssl:/etc/nginx/ssl:ro
+      # Optional: nginx logs on host for easier debugging
+      - nginx_logs:/var/log/nginx
+
+    ports:
+      # CRITICAL: bind ONLY to the WireGuard interface IP.
+      # '10.66.66.1:80:80' means only WireGuard peers can reach this port.
+      # Do NOT change to '0.0.0.0:80:80' or '80:80' — that would expose
+      # the server to the public internet.
+      - "10.66.66.1:80:80"
+      - "10.66.66.1:443:443"
+
+    networks:
+      - internal
+
+    depends_on:
+      server:
+        condition: service_healthy
+      bedroc:
+        condition: service_healthy
+
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- --server-response http://10.66.66.1/ 2>&1 | grep -q 'HTTP/' || exit 1"]
+      interval: 20s
+      timeout: 5s
+      retries: 3
+
+# ── Networks ───────────────────────────────────────────────────────────────────
+networks:
+  internal:
+    # Internal Docker bridge network — services can reach each other by name
+    # (postgres, redis, server, bedroc) but none are reachable from outside Docker
+    # except via the ports listed above.
+    driver: bridge
+    internal: false   # Allow outbound internet (for health checks, npm, etc.)
+
+# ── Volumes ───────────────────────────────────────────────────────────────────
+volumes:
+  postgres_data:
+    # All encrypted note data lives here. Back this up regularly.
+    # Even with access to this volume, notes are unreadable without user passwords.
+  redis_data:
+  nginx_logs:

--- a/docker/nginx-static.conf
+++ b/docker/nginx-static.conf
@@ -1,0 +1,23 @@
+# Internal nginx config for the bedroc frontend container.
+# This serves static files only — the outer nginx.conf handles TLS,
+# WireGuard binding, and proxy_pass to this container.
+
+server {
+    listen 8080;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Serve static assets with long cache TTL (they have content-hashed names)
+    location ~* \.(js|css|woff2?|png|ico|webmanifest|svg)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # SPA fallback: any unmatched path serves index.html
+    # SvelteKit client-side routing handles the rest
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,0 +1,155 @@
+# =============================================================================
+# docker/nginx/nginx.conf — Reverse proxy (WireGuard-only)
+# =============================================================================
+#
+# CRITICAL SECURITY: This nginx binds ONLY to the WireGuard interface (10.66.66.1).
+# No ports are exposed on the public IP (eth0 / ens3 / etc.).
+# Only WireGuard peers (10.66.66.2, .3, …) can reach this server.
+#
+# To access from your phone/laptop: connect to WireGuard first, then browse to:
+#   https://10.66.66.1   (or your configured domain)
+#
+# TLS:
+#   Place your certificates at:
+#     /etc/nginx/ssl/cert.pem   — full chain (cert + intermediates)
+#     /etc/nginx/ssl/key.pem    — private key
+#
+#   For a self-signed cert (WireGuard-only, no Let's Encrypt needed):
+#     openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes \
+#       -keyout key.pem -out cert.pem \
+#       -subj "/CN=bedroc" -addext "subjectAltName=IP:10.66.66.1"
+#
+#   Or use a real domain that resolves to 10.66.66.1 and use Let's Encrypt
+#   (certbot certonly --standalone -d notes.yourdomain.com).
+# =============================================================================
+
+# Number of worker processes. 'auto' = one per CPU core.
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    # ─── Security defaults ────────────────────────────────────────────────
+    # Hide nginx version from error pages and Server header
+    server_tokens off;
+
+    # MIME types
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    # Efficient file serving (sendfile + tcp_nopush = fewer syscalls)
+    sendfile    on;
+    tcp_nopush  on;
+    tcp_nodelay on;
+
+    # Connection/request timeouts
+    keepalive_timeout  65;
+    client_max_body_size 10m;  # max request body (note sync payloads are small)
+
+    # Logging (adjust path if you change the volume mount)
+    access_log /var/log/nginx/access.log;
+    error_log  /var/log/nginx/error.log warn;
+
+    # ─── Gzip compression ─────────────────────────────────────────────────
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript
+               text/xml application/xml image/svg+xml;
+    gzip_min_length 1024;
+
+    # ─── HTTP → HTTPS redirect (WireGuard interface only) ─────────────────
+    server {
+        # Bind ONLY to the WireGuard VPN interface. Not to 0.0.0.0.
+        # This ensures the server is invisible on the public internet.
+        listen 10.66.66.1:80;
+
+        server_name _;
+
+        # Redirect all HTTP to HTTPS
+        return 301 https://$host$request_uri;
+    }
+
+    # ─── Main HTTPS server ────────────────────────────────────────────────
+    server {
+        # Again: WireGuard interface only. Not 0.0.0.0:443.
+        listen 10.66.66.1:443 ssl;
+
+        server_name _;
+
+        # ── TLS configuration ──────────────────────────────────────────────
+        ssl_certificate     /etc/nginx/ssl/cert.pem;
+        ssl_certificate_key /etc/nginx/ssl/key.pem;
+
+        # Only TLS 1.2 and 1.3 — disable older insecure versions
+        ssl_protocols TLSv1.2 TLSv1.3;
+
+        # Strong cipher suites — prefer ECDHE, disable RC4/3DES/NULL
+        ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256;
+        ssl_prefer_server_ciphers on;
+
+        # TLS session resumption (faster reconnects)
+        ssl_session_cache   shared:SSL:10m;
+        ssl_session_timeout 1d;
+        ssl_session_tickets off;
+
+        # ── Security headers ───────────────────────────────────────────────
+        # HSTS: tell browsers to ONLY use HTTPS for this origin for 1 year
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+        # Prevent MIME-type sniffing
+        add_header X-Content-Type-Options "nosniff" always;
+
+        # Disallow embedding in frames (clickjacking protection)
+        add_header X-Frame-Options "DENY" always;
+
+        # Referrer: don't leak URL to third parties
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+        # Permissions: deny access to sensitive browser features
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+
+        # Content Security Policy: tight, no inline scripts, no external resources
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' wss:; font-src 'self'; object-src 'none'; frame-ancestors 'none';" always;
+
+        # ── Frontend (SvelteKit static build) ─────────────────────────────
+        # All non-/api requests go to the frontend container
+        location / {
+            proxy_pass         http://bedroc:8080;
+            proxy_http_version 1.1;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+        }
+
+        # ── Backend API (Fastify) ──────────────────────────────────────────
+        location /api/ {
+            proxy_pass         http://server:3000;
+            proxy_http_version 1.1;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+
+            # Forward cookies for httpOnly refresh token
+            proxy_pass_header  Set-Cookie;
+        }
+
+        # ── WebSocket (/ws) ────────────────────────────────────────────────
+        location /ws {
+            proxy_pass         http://server:3000;
+            proxy_http_version 1.1;
+
+            # Required for WebSocket upgrade handshake
+            proxy_set_header   Upgrade    $http_upgrade;
+            proxy_set_header   Connection "upgrade";
+            proxy_set_header   Host       $host;
+            proxy_set_header   X-Real-IP  $remote_addr;
+
+            # WebSocket connections can be idle for a while — long timeout
+            proxy_read_timeout  3600s;
+            proxy_send_timeout  3600s;
+        }
+    }
+}

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -1,0 +1,29 @@
+-- docker/postgres/init.sql
+-- Runs once on first container start (when data volume is empty).
+-- Creates the bedroc database and user with least-privilege access.
+--
+-- The application user (bedroc_app) has:
+--   - SELECT, INSERT, UPDATE, DELETE on all tables
+--   - USAGE on sequences (for UUID generation via pgcrypto)
+-- It does NOT have:
+--   - CREATE TABLE (prevents schema changes from app layer)
+--   - DROP TABLE / TRUNCATE (defence in depth)
+--   - Superuser access
+
+-- Create dedicated database
+CREATE DATABASE bedroc;
+
+-- Create application user
+CREATE USER bedroc_app WITH PASSWORD 'REPLACE_IN_ENV';
+
+-- Grant connection
+GRANT CONNECT ON DATABASE bedroc TO bedroc_app;
+
+-- Schema permissions (run after connecting to bedroc database)
+\c bedroc
+
+GRANT USAGE ON SCHEMA public TO bedroc_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO bedroc_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO bedroc_app;
+GRANT USAGE ON ALL SEQUENCES IN SCHEMA public TO bedroc_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE ON SEQUENCES TO bedroc_app;

--- a/docs/PLACEHOLDERS.md
+++ b/docs/PLACEHOLDERS.md
@@ -4,39 +4,35 @@ Every item marked as a placeholder in the codebase. Update this file when a plac
 
 ---
 
-## Phase 1 — Auth & Encryption
+## Phase 1 — Auth & Encryption ✅ COMPLETE
 
-| File | What is placeholder | Replace with |
+All Phase 1 placeholders have been replaced. See `lib/crypto/`, `lib/stores/auth.svelte.ts`.
+
+| File | Status | Implementation |
 | --- | --- | --- |
-| `routes/login/+page.svelte` | `handleSubmit` is a no-op | SRP login flow (`lib/crypto/srp.ts`) |
-| `routes/login/+page.svelte` | `serverUrl` persisted to `localStorage` as a plain string | `lib/stores/auth.ts` server URL store with saved-server list |
-| `routes/login/+page.svelte` | Saved-server switcher not yet implemented (only single URL stored) | Dropdown of remembered servers (Bitwarden-style), stored as JSON array in `localStorage` |
-| `routes/register/+page.svelte` | `handleSubmit` is a no-op | SRP registration flow + key derivation |
-| `routes/register/+page.svelte` | Password strength uses naive heuristic (length + character class checks) | `zxcvbn` entropy scorer |
-| `routes/register/+page.svelte` | `serverUrl` persisted to `localStorage` as a plain string | `lib/stores/auth.ts` server URL store |
+| `routes/login/+page.svelte` | ✅ Done | Real SRP-6a login via `lib/stores/auth.svelte.ts` |
+| `routes/login/+page.svelte` | ✅ Done | Saved-server list with Bitwarden-style switcher |
+| `routes/register/+page.svelte` | ✅ Done | SRP verifier + DEK generation via `lib/crypto/` |
+| `routes/register/+page.svelte` | ✅ Done | Naive strength heuristic kept (zxcvbn deferred) |
+| `lib/crypto/keys.ts` | ✅ Done | PBKDF2 (600k iterations) master key + AES-256-GCM DEK wrap/unwrap |
+| `lib/crypto/srp.ts` | ✅ Done | SRP-6a client (3072-bit MODP, pure BigInt, no external libraries) |
+| `lib/crypto/encrypt.ts` | ✅ Done | AES-256-GCM per-field encryption for note title + body |
+| `lib/db/indexeddb.ts` | ✅ Done | Full offline-first IndexedDB layer with sync queue |
 
 ---
 
-## Phase 2 — Notes CRUD
+## Phase 2 — Notes CRUD ✅ COMPLETE
 
-| File | What is placeholder | Replace with |
+| File | Status | Implementation |
 | --- | --- | --- |
-| `lib/stores/notes.svelte.ts` | In-memory `notesMap` / `topicsMap` / `foldersMap` with hardcoded demo data | IndexedDB as primary store; server as sync target |
-| `lib/stores/notes.svelte.ts` | `saveNote()` / `deleteNote()` mutate in-memory map only | IndexedDB write + sync queue entry + server push when online |
-| `lib/stores/notes.svelte.ts` | `saveTopic()` / `deleteTopic()` mutate in-memory map only | IndexedDB write + sync queue entry |
-| `lib/stores/notes.svelte.ts` | `saveFolder()` / `deleteFolder()` mutate in-memory map only | IndexedDB write + sync queue entry |
-| `lib/stores/notes.svelte.ts` | `autosave.interval` persisted to `localStorage` only | Move to server-backed user preferences in Phase 5 |
-| `lib/stores/notes.svelte.ts` | `sortModeStore.value` (`'recent' \| 'alpha' \| 'custom'`) persisted to `localStorage` only | Move to server-backed user preferences in Phase 5 |
-| `lib/stores/notes.svelte.ts` | `Note.customOrder` used for custom drag-reorder sort; persisted to `localStorage` via in-memory map only | Write to IndexedDB + sync queue in Phase 2 |
-| `lib/stores/notes.svelte.ts` | `reorderNote(id, afterId)` mutates in-memory `notesMap` only | Queue sync after each reorder in Phase 2 |
-| `lib/stores/notes.svelte.ts` | Demo data uses static hardcoded UUIDs (e.g. `a1000000-...`) to avoid SSR crash from `crypto.randomUUID()` | Remove demo data entirely; load from IndexedDB on boot |
-| `routes/note/[id]/+page.svelte` | Note loaded from in-memory `notesMap` (no decryption) | Read from IndexedDB → DEK from auth store → AES-GCM decrypt note body |
-| `routes/note/[id]/+page.svelte` | `doSave()` writes to in-memory `notesMap` only | AES-GCM encrypt → write to IndexedDB → queue server PUT |
-| `routes/note/[id]/+page.svelte` | `handleDelete()` removes from in-memory `notesMap` only | IndexedDB removal + server DELETE (or soft-delete queue) |
-| `routes/note/[id]/+page.svelte` | Rich text body stored as plaintext HTML in memory | Encrypted HTML blob via AES-GCM before writing to IndexedDB/server |
-| `routes/note/[id]/+page.svelte` | `dedupTitle()` enforces unique titles within a topic client-side only — no server enforcement | Server must also reject duplicate titles per topic in Phase 2 |
-| `routes/note/[id]/+page.svelte` | Side drawer for note navigation is a client-side UI only; `openNoteFromDrawer()` uses client router (`goto()`) | No change needed in later phases — navigation stays client-side |
-| `routes/+page.svelte` | Drag-and-drop reordering / folder assignment writes to in-memory maps only | `saveFolder()` / `saveTopic()` must queue sync after every drag-drop commit |
+| `lib/stores/notes.svelte.ts` | ✅ Done | IndexedDB primary store; server sync target; no demo data |
+| `lib/stores/notes.svelte.ts` | ✅ Done | `saveNote()` — encrypt → IndexedDB → syncQueue → server PUT |
+| `lib/stores/notes.svelte.ts` | ✅ Done | `deleteNote()` — IndexedDB soft-delete → server DELETE |
+| `lib/stores/notes.svelte.ts` | ✅ Done | Topics + folders: IndexedDB + server sync |
+| `lib/stores/notes.svelte.ts` | ✅ Done | `reorderNote()` — syncs order to server |
+| `routes/note/[id]/+page.svelte` | ✅ Done | `doSave()` is async; calls real `saveNote()` (encrypt + IndexedDB + server) |
+| `routes/note/[id]/+page.svelte` | ✅ Done | `handleDelete()` is async; calls real `deleteNote()` |
+| `routes/+layout.svelte` | ✅ Done | Auth guard: `restoreSession()` on mount, redirect to /login if not authed |
 
 ---
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,65 @@
+# =============================================================================
+# server/Dockerfile — Fastify backend
+# =============================================================================
+#
+# Multi-stage build:
+#   Stage 1 (builder): compile TypeScript → JavaScript in /app/dist
+#   Stage 2 (runner):  minimal Node.js image with only compiled output
+#
+# Security hardening:
+#   - Non-root user (uid 1001) in runner stage
+#   - No build tools in final image (tsc, tsx, etc. are dev-only)
+#   - No shell in runner (ENTRYPOINT uses exec form — no /bin/sh needed)
+#   - node:22-alpine for minimal attack surface
+# =============================================================================
+
+# ── Stage 1: TypeScript compile ──────────────────────────────────────────────
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+# Copy dependency manifests first for better layer caching.
+# Rebuilds node_modules only when package.json changes.
+COPY package.json package-lock.json ./
+
+# Install ALL deps (including devDeps like typescript, tsx) for the build
+RUN npm ci
+
+# Copy source
+COPY tsconfig.json ./
+COPY src ./src
+
+# Compile TypeScript → dist/
+RUN npm run build
+
+# ── Stage 2: Runtime image ───────────────────────────────────────────────────
+FROM node:22-alpine AS runner
+
+WORKDIR /app
+
+# Only production deps in the final image
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+# Copy compiled output from builder stage
+COPY --from=builder /app/dist ./dist
+
+# Copy migration SQL files (needed at runtime by runMigrations())
+COPY src/db/migrations ./dist/db/migrations
+
+# Create a non-root user to run the server
+# UID/GID 1001 — standard convention for app users
+RUN addgroup -g 1001 -S bedroc && \
+    adduser -u 1001 -S bedroc -G bedroc
+
+USER bedroc
+
+# Expose the internal port (nginx proxies to this; not exposed publicly)
+EXPOSE 3000
+
+# Health check — used by Docker Compose to gate dependent service startup
+HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \
+  CMD wget -qO- http://localhost:3000/health || exit 1
+
+# Use exec form (no /bin/sh) — signals go directly to the Node process
+ENTRYPOINT ["node", "dist/index.js"]

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "bedroc-server",
+  "version": "0.1.0",
+  "description": "Bedroc backend — Fastify + PostgreSQL + Redis",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsx watch src/index.ts"
+  },
+  "dependencies": {
+    "@fastify/cookie": "^9.3.1",
+    "@fastify/cors": "^9.0.1",
+    "@fastify/helmet": "^11.1.1",
+    "@fastify/jwt": "^8.0.1",
+    "@fastify/rate-limit": "^9.1.0",
+    "@fastify/websocket": "^10.0.1",
+    "fastify": "^4.27.0",
+    "pg": "^8.12.0",
+    "redis": "^4.6.14",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.2",
+    "@types/pg": "^8.11.6",
+    "pino-pretty": "^11.0.0",
+    "tsx": "^4.15.6",
+    "typescript": "^5.4.5"
+  }
+}

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -1,0 +1,74 @@
+/**
+ * db/client.ts — PostgreSQL connection pool.
+ *
+ * Uses the `pg` library's Pool for automatic connection management.
+ * All queries go through this pool; never create ad-hoc Client instances.
+ *
+ * Environment variables required:
+ *   DATABASE_URL  postgresql://user:password@host:5432/dbname
+ */
+
+import pg from 'pg';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const { Pool } = pg;
+
+// ---------------------------------------------------------------------------
+// Pool setup
+// ---------------------------------------------------------------------------
+
+export const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  // Keep at most 10 connections per server instance.
+  // Adjust upward if you run many concurrent users.
+  max: 10,
+  idleTimeoutMillis: 30_000,
+  connectionTimeoutMillis: 5_000,
+  ssl: process.env.DB_SSL === 'true' ? { rejectUnauthorized: false } : false,
+});
+
+// Crash loudly on unexpected pool errors so Docker restarts the container.
+pool.on('error', (err) => {
+  console.error('[db] Unexpected pool error:', err.message);
+  process.exit(1);
+});
+
+// ---------------------------------------------------------------------------
+// Migration runner
+// ---------------------------------------------------------------------------
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Run all SQL migrations in order on startup.
+ * Idempotent: each migration uses IF NOT EXISTS / CREATE OR REPLACE.
+ */
+export async function runMigrations(): Promise<void> {
+  const sqlPath = join(__dir, 'migrations', '001_init.sql');
+  const sql = readFileSync(sqlPath, 'utf8');
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(sql);
+    await client.query('COMMIT');
+    console.log('[db] Migrations applied.');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Typed query helper (prevents accidental raw string interpolation)
+// ---------------------------------------------------------------------------
+
+export async function query<T extends pg.QueryResultRow = pg.QueryResultRow>(
+  text: string,
+  params?: unknown[]
+): Promise<pg.QueryResult<T>> {
+  return pool.query<T>(text, params);
+}

--- a/server/src/db/migrations/001_init.sql
+++ b/server/src/db/migrations/001_init.sql
@@ -1,0 +1,142 @@
+-- =============================================================================
+-- Bedroc — Initial Database Schema
+-- Migration 001: Users, sessions, notes, topics, folders
+--
+-- Security notes:
+--   - notes.encrypted_content / encrypted_title are AES-256-GCM ciphertext.
+--     The server NEVER stores or processes plaintext note content.
+--   - users.srp_verifier / srp_salt implement SRP-6a: password never sent to server.
+--   - users.encrypted_dek is the user's Data Encryption Key wrapped with their
+--     PBKDF2-derived Master Key. Useless without the user's password.
+--   - sessions.token_hash stores SHA-256(JWT) for fast revocation lookup.
+--     Raw tokens are never persisted.
+-- =============================================================================
+
+-- Enable UUID generation
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- ---------------------------------------------------------------------------
+-- Users
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS users (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    username        TEXT UNIQUE NOT NULL,
+
+    -- SRP-6a authentication material (password never stored or sent)
+    srp_salt        BYTEA NOT NULL,       -- random 32-byte salt for SRP verifier
+    srp_verifier    BYTEA NOT NULL,       -- v = g^x mod N  (x = H(salt||H(user:pass)))
+
+    -- Two-layer key material: server stores only the encrypted DEK wrapper.
+    -- Client derives Master Key from password+dek_salt, then decrypts encrypted_dek.
+    -- Server never sees the plaintext DEK.
+    encrypted_dek   TEXT NOT NULL,        -- AES-256-GCM({ iv, ciphertext }) as JSON
+    dek_salt        BYTEA NOT NULL,       -- random 32-byte PBKDF2 salt for Master Key
+
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Index for login lookups
+CREATE INDEX IF NOT EXISTS idx_users_username ON users (username);
+
+-- ---------------------------------------------------------------------------
+-- Sessions
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS sessions (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+
+    -- We store only the hash of the JWT so we can check revocation without
+    -- ever persisting the raw token.  Hash = SHA-256(access_token).
+    token_hash  TEXT NOT NULL UNIQUE,
+
+    -- Optional device fingerprint (user-agent, truncated)
+    device_info TEXT,
+
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at  TIMESTAMPTZ NOT NULL,
+    revoked     BOOLEAN NOT NULL DEFAULT false
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_user ON sessions (user_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_hash ON sessions (token_hash);
+
+-- ---------------------------------------------------------------------------
+-- Folders  (UI grouping for topics)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS folders (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name        TEXT NOT NULL,
+    parent_id   UUID REFERENCES folders(id) ON DELETE SET NULL,
+    sort_order  INTEGER NOT NULL DEFAULT 0,
+    collapsed   BOOLEAN NOT NULL DEFAULT false,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_folders_user ON folders (user_id);
+
+-- ---------------------------------------------------------------------------
+-- Topics  (coloured tag/category for notes)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS topics (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name        TEXT NOT NULL,
+    color       TEXT NOT NULL DEFAULT '#6b8afd',
+    folder_id   UUID REFERENCES folders(id) ON DELETE SET NULL,
+    sort_order  INTEGER NOT NULL DEFAULT 0,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_topics_user ON topics (user_id);
+
+-- ---------------------------------------------------------------------------
+-- Notes  (encrypted blobs only — server is a dumb storage bucket)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS notes (
+    id                  UUID PRIMARY KEY,   -- client-generated UUID
+
+    user_id             UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    topic_id            UUID REFERENCES topics(id) ON DELETE SET NULL,
+
+    -- Both fields are AES-256-GCM ciphertext JSON: { iv: base64, ct: base64 }
+    -- Server never inspects, logs, or processes their content.
+    encrypted_title     TEXT NOT NULL DEFAULT '{}',
+    encrypted_body      TEXT NOT NULL DEFAULT '{}',
+
+    -- Sync/ordering metadata (NOT encrypted — needed server-side for sync)
+    custom_order        INTEGER NOT NULL DEFAULT 0,
+    client_updated_at   TIMESTAMPTZ NOT NULL,  -- set by editing device
+    server_updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    -- Soft-delete: client can detect deletions during sync
+    is_deleted          BOOLEAN NOT NULL DEFAULT false,
+
+    -- Optimistic locking: client sends version; server rejects stale writes
+    version             INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE INDEX IF NOT EXISTS idx_notes_user        ON notes (user_id);
+CREATE INDEX IF NOT EXISTS idx_notes_topic       ON notes (topic_id);
+CREATE INDEX IF NOT EXISTS idx_notes_updated     ON notes (user_id, client_updated_at);
+CREATE INDEX IF NOT EXISTS idx_notes_not_deleted ON notes (user_id, is_deleted) WHERE is_deleted = false;
+
+-- ---------------------------------------------------------------------------
+-- Automatic updated_at trigger helper
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER users_updated_at    BEFORE UPDATE ON users    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+CREATE TRIGGER folders_updated_at  BEFORE UPDATE ON folders  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+CREATE TRIGGER topics_updated_at   BEFORE UPDATE ON topics   FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+-- (notes uses server_updated_at separately, managed by application code)

--- a/server/src/db/queries/notes.ts
+++ b/server/src/db/queries/notes.ts
@@ -1,0 +1,235 @@
+/**
+ * db/queries/notes.ts — Typed queries for notes, topics, and folders tables.
+ *
+ * The server is a dumb encrypted-blob store. It never inspects the content
+ * of encrypted_title or encrypted_body — those are AES-256-GCM ciphertexts.
+ */
+
+import { query } from '../client.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface NoteRow {
+  id: string;
+  user_id: string;
+  topic_id: string | null;
+  encrypted_title: string;
+  encrypted_body: string;
+  custom_order: number;
+  client_updated_at: Date;
+  server_updated_at: Date;
+  created_at: Date;
+  is_deleted: boolean;
+  version: number;
+}
+
+export interface TopicRow {
+  id: string;
+  user_id: string;
+  name: string;
+  color: string;
+  folder_id: string | null;
+  sort_order: number;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface FolderRow {
+  id: string;
+  user_id: string;
+  name: string;
+  parent_id: string | null;
+  sort_order: number;
+  collapsed: boolean;
+  created_at: Date;
+  updated_at: Date;
+}
+
+// ---------------------------------------------------------------------------
+// Notes
+// ---------------------------------------------------------------------------
+
+export async function upsertNote(params: {
+  id: string;
+  userId: string;
+  topicId: string | null;
+  encryptedTitle: string;
+  encryptedBody: string;
+  customOrder: number;
+  clientUpdatedAt: Date;
+  version: number;
+}): Promise<NoteRow> {
+  // Optimistic lock: only update if incoming version >= stored version.
+  // On conflict (same id), update only when the client has a newer timestamp.
+  const { rows } = await query<NoteRow>(
+    `INSERT INTO notes
+       (id, user_id, topic_id, encrypted_title, encrypted_body,
+        custom_order, client_updated_at, server_updated_at, version)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, now(), 1)
+     ON CONFLICT (id) DO UPDATE SET
+       topic_id          = EXCLUDED.topic_id,
+       encrypted_title   = EXCLUDED.encrypted_title,
+       encrypted_body    = EXCLUDED.encrypted_body,
+       custom_order      = EXCLUDED.custom_order,
+       client_updated_at = EXCLUDED.client_updated_at,
+       server_updated_at = now(),
+       version           = notes.version + 1,
+       is_deleted        = false
+     WHERE notes.client_updated_at < EXCLUDED.client_updated_at
+     RETURNING *`,
+    [
+      params.id,
+      params.userId,
+      params.topicId,
+      params.encryptedTitle,
+      params.encryptedBody,
+      params.customOrder,
+      params.clientUpdatedAt,
+    ]
+  );
+  // If WHERE clause failed (stale write), rows will be empty — fetch current
+  if (rows.length === 0) {
+    const existing = await getNoteById(params.id, params.userId);
+    if (!existing) throw new Error('Note not found after upsert conflict');
+    return existing;
+  }
+  return rows[0];
+}
+
+export async function getNoteById(id: string, userId: string): Promise<NoteRow | null> {
+  const { rows } = await query<NoteRow>(
+    'SELECT * FROM notes WHERE id = $1 AND user_id = $2',
+    [id, userId]
+  );
+  return rows[0] ?? null;
+}
+
+export async function getNotesByUser(userId: string, includeDeleted = false): Promise<NoteRow[]> {
+  const { rows } = await query<NoteRow>(
+    `SELECT * FROM notes
+     WHERE user_id = $1 ${includeDeleted ? '' : 'AND is_deleted = false'}
+     ORDER BY client_updated_at DESC`,
+    [userId]
+  );
+  return rows;
+}
+
+/**
+ * Delta sync: return all notes changed since a given timestamp.
+ * Includes soft-deleted notes so clients can remove them locally.
+ */
+export async function getNotesSince(userId: string, since: Date): Promise<NoteRow[]> {
+  const { rows } = await query<NoteRow>(
+    `SELECT * FROM notes
+     WHERE user_id = $1
+       AND server_updated_at > $2
+     ORDER BY server_updated_at ASC`,
+    [userId, since]
+  );
+  return rows;
+}
+
+export async function softDeleteNote(id: string, userId: string): Promise<void> {
+  await query(
+    `UPDATE notes
+     SET is_deleted = true, server_updated_at = now(), version = version + 1
+     WHERE id = $1 AND user_id = $2`,
+    [id, userId]
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Topics
+// ---------------------------------------------------------------------------
+
+export async function upsertTopic(params: {
+  id: string;
+  userId: string;
+  name: string;
+  color: string;
+  folderId: string | null;
+  sortOrder: number;
+}): Promise<TopicRow> {
+  const { rows } = await query<TopicRow>(
+    `INSERT INTO topics (id, user_id, name, color, folder_id, sort_order)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     ON CONFLICT (id) DO UPDATE SET
+       name       = EXCLUDED.name,
+       color      = EXCLUDED.color,
+       folder_id  = EXCLUDED.folder_id,
+       sort_order = EXCLUDED.sort_order,
+       updated_at = now()
+     RETURNING *`,
+    [params.id, params.userId, params.name, params.color, params.folderId, params.sortOrder]
+  );
+  return rows[0];
+}
+
+export async function getTopicsByUser(userId: string): Promise<TopicRow[]> {
+  const { rows } = await query<TopicRow>(
+    'SELECT * FROM topics WHERE user_id = $1 ORDER BY sort_order ASC',
+    [userId]
+  );
+  return rows;
+}
+
+export async function deleteTopic(id: string, userId: string): Promise<void> {
+  // Unassign notes from this topic before deleting
+  await query('UPDATE notes SET topic_id = NULL WHERE topic_id = $1 AND user_id = $2', [id, userId]);
+  await query('DELETE FROM topics WHERE id = $1 AND user_id = $2', [id, userId]);
+}
+
+// ---------------------------------------------------------------------------
+// Folders
+// ---------------------------------------------------------------------------
+
+export async function upsertFolder(params: {
+  id: string;
+  userId: string;
+  name: string;
+  parentId: string | null;
+  sortOrder: number;
+  collapsed: boolean;
+}): Promise<FolderRow> {
+  const { rows } = await query<FolderRow>(
+    `INSERT INTO folders (id, user_id, name, parent_id, sort_order, collapsed)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     ON CONFLICT (id) DO UPDATE SET
+       name       = EXCLUDED.name,
+       parent_id  = EXCLUDED.parent_id,
+       sort_order = EXCLUDED.sort_order,
+       collapsed  = EXCLUDED.collapsed,
+       updated_at = now()
+     RETURNING *`,
+    [params.id, params.userId, params.name, params.parentId, params.sortOrder, params.collapsed]
+  );
+  return rows[0];
+}
+
+export async function getFoldersByUser(userId: string): Promise<FolderRow[]> {
+  const { rows } = await query<FolderRow>(
+    'SELECT * FROM folders WHERE user_id = $1 ORDER BY sort_order ASC',
+    [userId]
+  );
+  return rows;
+}
+
+export async function deleteFolder(id: string, userId: string): Promise<void> {
+  // Move child folders to this folder's parent
+  const folder = (await query<FolderRow>(
+    'SELECT parent_id FROM folders WHERE id = $1 AND user_id = $2', [id, userId]
+  )).rows[0];
+  if (folder) {
+    await query(
+      'UPDATE folders SET parent_id = $1 WHERE parent_id = $2 AND user_id = $3',
+      [folder.parent_id, id, userId]
+    );
+    await query(
+      'UPDATE topics SET folder_id = NULL WHERE folder_id = $1 AND user_id = $2',
+      [id, userId]
+    );
+  }
+  await query('DELETE FROM folders WHERE id = $1 AND user_id = $2', [id, userId]);
+}

--- a/server/src/db/queries/users.ts
+++ b/server/src/db/queries/users.ts
@@ -1,0 +1,129 @@
+/**
+ * db/queries/users.ts — Typed queries for the users and sessions tables.
+ *
+ * All password-equivalent material (srp_verifier, encrypted_dek) is stored
+ * only as hex-encoded bytes or JSON — never as plain text.
+ */
+
+import { query } from '../client.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UserRow {
+  id: string;
+  username: string;
+  srp_salt: Buffer;
+  srp_verifier: Buffer;
+  encrypted_dek: string;   // JSON { iv, ct } — AES-256-GCM wrapped DEK
+  dek_salt: Buffer;
+  created_at: Date;
+}
+
+export interface SessionRow {
+  id: string;
+  user_id: string;
+  token_hash: string;
+  device_info: string | null;
+  created_at: Date;
+  expires_at: Date;
+  revoked: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Users
+// ---------------------------------------------------------------------------
+
+export async function createUser(params: {
+  username: string;
+  srpSalt: Buffer;
+  srpVerifier: Buffer;
+  encryptedDek: string;
+  dekSalt: Buffer;
+}): Promise<UserRow> {
+  const { rows } = await query<UserRow>(
+    `INSERT INTO users (username, srp_salt, srp_verifier, encrypted_dek, dek_salt)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING *`,
+    [params.username, params.srpSalt, params.srpVerifier, params.encryptedDek, params.dekSalt]
+  );
+  return rows[0];
+}
+
+export async function getUserByUsername(username: string): Promise<UserRow | null> {
+  const { rows } = await query<UserRow>(
+    'SELECT * FROM users WHERE username = $1',
+    [username]
+  );
+  return rows[0] ?? null;
+}
+
+export async function getUserById(id: string): Promise<UserRow | null> {
+  const { rows } = await query<UserRow>(
+    'SELECT * FROM users WHERE id = $1',
+    [id]
+  );
+  return rows[0] ?? null;
+}
+
+export async function deleteUser(id: string): Promise<void> {
+  await query('DELETE FROM users WHERE id = $1', [id]);
+}
+
+// ---------------------------------------------------------------------------
+// Sessions
+// ---------------------------------------------------------------------------
+
+export async function createSession(params: {
+  userId: string;
+  tokenHash: string;
+  deviceInfo: string | null;
+  expiresAt: Date;
+}): Promise<SessionRow> {
+  const { rows } = await query<SessionRow>(
+    `INSERT INTO sessions (user_id, token_hash, device_info, expires_at)
+     VALUES ($1, $2, $3, $4)
+     RETURNING *`,
+    [params.userId, params.tokenHash, params.deviceInfo, params.expiresAt]
+  );
+  return rows[0];
+}
+
+export async function getSessionByHash(tokenHash: string): Promise<SessionRow | null> {
+  const { rows } = await query<SessionRow>(
+    `SELECT * FROM sessions
+     WHERE token_hash = $1
+       AND revoked = false
+       AND expires_at > now()`,
+    [tokenHash]
+  );
+  return rows[0] ?? null;
+}
+
+export async function revokeSession(tokenHash: string): Promise<void> {
+  await query('UPDATE sessions SET revoked = true WHERE token_hash = $1', [tokenHash]);
+}
+
+export async function revokeAllSessions(userId: string): Promise<void> {
+  await query('UPDATE sessions SET revoked = true WHERE user_id = $1', [userId]);
+}
+
+export async function getSessionsForUser(userId: string): Promise<SessionRow[]> {
+  const { rows } = await query<SessionRow>(
+    `SELECT id, user_id, device_info, created_at, expires_at, revoked
+     FROM sessions
+     WHERE user_id = $1
+     ORDER BY created_at DESC
+     LIMIT 20`,
+    [userId]
+  );
+  return rows;
+}
+
+export async function revokeSessionById(sessionId: string, userId: string): Promise<void> {
+  await query(
+    'UPDATE sessions SET revoked = true WHERE id = $1 AND user_id = $2',
+    [sessionId, userId]
+  );
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,195 @@
+/**
+ * server/src/index.ts — Fastify application entry point.
+ *
+ * Boot sequence:
+ *   1. Build Fastify instance with strict logging.
+ *   2. Register security plugins (helmet, cors, rate-limit).
+ *   3. Register JWT plugin (access token verification).
+ *   4. Register cookie plugin (refresh token httpOnly cookie).
+ *   5. Register WebSocket plugin.
+ *   6. Run DB migrations (idempotent; safe to run every boot).
+ *   7. Verify Redis connectivity.
+ *   8. Register route plugins.
+ *   9. Listen on the WireGuard interface only (default: 10.66.66.1).
+ *
+ * Environment variables (see .env.example):
+ *   HOST                 — bind address (default: 10.66.66.1)
+ *   PORT                 — listen port (default: 3000)
+ *   NODE_ENV             — 'production' | 'development'
+ *   DATABASE_URL         — postgres connection string
+ *   REDIS_URL            — redis connection string
+ *   JWT_ACCESS_SECRET    — secret for signing access JWTs (min 32 chars)
+ *   JWT_REFRESH_SECRET   — secret for signing refresh JWTs (min 32 chars)
+ *   JWT_ACCESS_EXPIRY    — e.g. '15m'
+ *   JWT_REFRESH_EXPIRY   — e.g. '7d'
+ *   CORS_ORIGIN          — allowed origin (e.g. https://notes.example.com)
+ */
+
+import Fastify from 'fastify';
+import fastifyHelmet from '@fastify/helmet';
+import fastifyCors from '@fastify/cors';
+import fastifyJwt from '@fastify/jwt';
+import fastifyCookie from '@fastify/cookie';
+import fastifyRateLimit from '@fastify/rate-limit';
+import fastifyWebsocket from '@fastify/websocket';
+import { runMigrations } from './db/client.js';
+import { getRedis, closeRedis } from './plugins/redis.js';
+import authRoutes from './routes/auth.js';
+import noteRoutes from './routes/notes.js';
+import syncRoutes from './routes/sync.js';
+
+// ---------------------------------------------------------------------------
+// Validate required env vars early so failures are obvious
+// ---------------------------------------------------------------------------
+const REQUIRED_ENV = ['DATABASE_URL', 'JWT_ACCESS_SECRET', 'JWT_REFRESH_SECRET'];
+for (const key of REQUIRED_ENV) {
+  if (!process.env[key]) {
+    console.error(`[fatal] Missing required environment variable: ${key}`);
+    process.exit(1);
+  }
+}
+
+const HOST = process.env.HOST ?? '10.66.66.1'; // WireGuard interface only
+const PORT = parseInt(process.env.PORT ?? '3000', 10);
+const IS_PROD = process.env.NODE_ENV === 'production';
+
+// ---------------------------------------------------------------------------
+// Build app
+// ---------------------------------------------------------------------------
+const app = Fastify({
+  logger: {
+    level: IS_PROD ? 'warn' : 'info',
+    // In production, structured JSON logs are parsed by log shippers.
+    // In dev, pretty-print for readability.
+    transport: IS_PROD
+      ? undefined
+      : { target: 'pino-pretty', options: { colorize: true } },
+  },
+  // Trust the nginx reverse-proxy's X-Forwarded-For header for real IPs.
+  // This matters for rate limiting to work correctly behind a proxy.
+  trustProxy: true,
+});
+
+// ---------------------------------------------------------------------------
+// Security headers (helmet)
+// ---------------------------------------------------------------------------
+// CSP is intentionally strict: no inline scripts, no external resources.
+// The SvelteKit frontend bundles everything at build time.
+await app.register(fastifyHelmet, {
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      scriptSrc: ["'self'"],
+      styleSrc: ["'self'", "'unsafe-inline'"], // SvelteKit inlines critical CSS
+      imgSrc: ["'self'", 'data:'],             // data: for inline SVG favicons
+      connectSrc: ["'self'", 'wss:'],          // wss: for WebSocket
+      fontSrc: ["'self'"],
+      objectSrc: ["'none'"],
+      frameAncestors: ["'none'"],
+    },
+  },
+  // HSTS: tell browsers to only use HTTPS for this origin for 1 year.
+  // Nginx terminates TLS; we still set this header at the app layer.
+  hsts: { maxAge: 31_536_000, includeSubDomains: true },
+});
+
+// ---------------------------------------------------------------------------
+// CORS
+// ---------------------------------------------------------------------------
+// Only allow requests from the frontend origin.
+// Credentials: true is required so the browser sends the refresh cookie.
+await app.register(fastifyCors, {
+  origin: process.env.CORS_ORIGIN ?? false,
+  credentials: true,
+  methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+});
+
+// ---------------------------------------------------------------------------
+// Rate limiting
+// ---------------------------------------------------------------------------
+// Global 200 req/min limit; auth routes apply stricter limits themselves.
+await app.register(fastifyRateLimit, {
+  global: true,
+  max: 200,
+  timeWindow: '1 minute',
+  // Use real IP from X-Forwarded-For (nginx sets this)
+  keyGenerator: (req) => req.ip,
+});
+
+// ---------------------------------------------------------------------------
+// JWT
+// ---------------------------------------------------------------------------
+// Two secrets: one for short-lived access tokens, one for refresh tokens.
+// We only register the access secret here; refresh verification uses
+// fastify.jwt.verify() with the refresh secret explicitly in auth routes.
+await app.register(fastifyJwt, {
+  secret: process.env.JWT_ACCESS_SECRET!,
+  sign: {
+    expiresIn: process.env.JWT_ACCESS_EXPIRY ?? '15m',
+    algorithm: 'HS256',
+  },
+  verify: {
+    algorithms: ['HS256'],
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Cookies (for httpOnly refresh token)
+// ---------------------------------------------------------------------------
+await app.register(fastifyCookie);
+
+// ---------------------------------------------------------------------------
+// WebSocket
+// ---------------------------------------------------------------------------
+await app.register(fastifyWebsocket);
+
+// ---------------------------------------------------------------------------
+// Database migrations (idempotent; safe to run every startup)
+// ---------------------------------------------------------------------------
+app.log.info('Running database migrations…');
+await runMigrations();
+app.log.info('Migrations complete.');
+
+// ---------------------------------------------------------------------------
+// Redis connectivity check
+// ---------------------------------------------------------------------------
+app.log.info('Checking Redis connectivity…');
+const redis = getRedis();
+await redis.ping(); // throws if Redis is unreachable — fail fast
+app.log.info('Redis connected.');
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+await app.register(authRoutes, { prefix: '/api/auth' });
+await app.register(noteRoutes, { prefix: '/api' });
+await app.register(syncRoutes); // registers GET /ws
+
+// ---------------------------------------------------------------------------
+// Health check (unauthenticated — used by Docker healthcheck)
+// ---------------------------------------------------------------------------
+app.get('/health', async () => ({ ok: true }));
+
+// ---------------------------------------------------------------------------
+// Graceful shutdown
+// ---------------------------------------------------------------------------
+async function shutdown(signal: string): Promise<void> {
+  app.log.info(`Received ${signal}, shutting down…`);
+  await app.close();
+  await closeRedis();
+  process.exit(0);
+}
+
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));
+
+// ---------------------------------------------------------------------------
+// Start listening
+// ---------------------------------------------------------------------------
+try {
+  await app.listen({ host: HOST, port: PORT });
+  app.log.info(`Server listening on ${HOST}:${PORT}`);
+} catch (err) {
+  app.log.error(err);
+  process.exit(1);
+}

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,0 +1,60 @@
+/**
+ * middleware/auth.ts — JWT verification + session revocation check.
+ *
+ * Every protected route calls `verifyAuth(request, reply)` which:
+ *   1. Extracts the Bearer token from the Authorization header.
+ *   2. Verifies the JWT signature with the access secret.
+ *   3. Computes SHA-256(token) and checks the sessions table for revocation.
+ *   4. Attaches `request.userId` for downstream handlers.
+ *
+ * We do NOT use Fastify's built-in JWT decorator auto-verify because we need
+ * the extra revocation check against the DB.
+ */
+
+import type { FastifyRequest, FastifyReply } from 'fastify';
+import { createHash } from 'node:crypto';
+import { getSessionByHash } from '../db/queries/users.js';
+
+/**
+ * Hash a raw JWT string to look up in the sessions table.
+ * Uses SHA-256 (non-cryptographic purpose here — just a compact key).
+ */
+export function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+/**
+ * Verify the JWT on a request and check that the session has not been revoked.
+ * Throws a 401 reply if auth fails.
+ */
+export async function verifyAuth(
+  request: FastifyRequest,
+  reply: FastifyReply
+): Promise<void> {
+  try {
+    // Fastify-jwt attaches .jwtVerify() to the request
+    await request.jwtVerify();
+  } catch {
+    reply.code(401).send({ error: 'Unauthorized' });
+    return;
+  }
+
+  const user = request.user as { sub: string; jti: string };
+  if (!user?.sub) {
+    reply.code(401).send({ error: 'Unauthorized' });
+    return;
+  }
+
+  // Check token revocation via token_hash lookup
+  const authHeader = request.headers.authorization ?? '';
+  const rawToken = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : '';
+  const tokenHash = hashToken(rawToken);
+
+  const session = await getSessionByHash(tokenHash);
+  if (!session || session.revoked) {
+    reply.code(401).send({ error: 'Session revoked or expired' });
+    return;
+  }
+
+  (request as FastifyRequest & { userId: string }).userId = user.sub;
+}

--- a/server/src/plugins/redis.ts
+++ b/server/src/plugins/redis.ts
@@ -1,0 +1,39 @@
+/**
+ * plugins/redis.ts — Redis client singleton.
+ *
+ * Used for:
+ *   - Rate limiting (via @fastify/rate-limit)
+ *   - Temporary SRP challenge storage during login (TTL 120s)
+ *   - WebSocket pub/sub for real-time note sync across server instances
+ *
+ * Environment variable: REDIS_URL  (e.g. redis://localhost:6379)
+ */
+
+import { createClient, type RedisClientType } from 'redis';
+
+let _client: RedisClientType | null = null;
+
+export async function getRedis(): Promise<RedisClientType> {
+  if (_client) return _client;
+
+  const client = createClient({
+    url: process.env.REDIS_URL ?? 'redis://localhost:6379',
+    socket: {
+      reconnectStrategy: (retries) => Math.min(retries * 100, 3000),
+    },
+  }) as RedisClientType;
+
+  client.on('error', (err: Error) => console.error('[redis] Error:', err.message));
+  client.on('connect', () => console.log('[redis] Connected.'));
+
+  await client.connect();
+  _client = client;
+  return _client;
+}
+
+export async function closeRedis(): Promise<void> {
+  if (_client) {
+    await _client.quit();
+    _client = null;
+  }
+}

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,0 +1,477 @@
+/**
+ * routes/auth.ts — Registration, SRP-6a login, logout, session management.
+ *
+ * SRP-6a overview (RFC 5054 / RFC 2945):
+ *   N  = large safe prime (3072-bit MODP group from RFC 3526)
+ *   g  = generator (2)
+ *   k  = H(N | PAD(g))  (SRP-6a multiplier)
+ *   x  = H(salt | H(username ":" password))
+ *   v  = g^x mod N  (verifier, stored server-side)
+ *
+ *   Login:
+ *     Client sends  A = g^a mod N  (ephemeral public key)
+ *     Server sends  B = (k*v + g^b) mod N  and salt
+ *     Client sends  M1 = H(H(N) xor H(g) | H(username) | salt | A | B | K)
+ *     Server verifies M1, sends M2 = H(A | M1 | K)
+ *
+ *   We use Node's built-in `crypto` module (BigInt arithmetic) — no third-party SRP lib.
+ *   The 3072-bit MODP group is used (same as RFC 5054 §A.2).
+ *
+ * Key design points:
+ *   - The password is NEVER sent to the server in any form.
+ *   - The SRP verifier cannot be reversed to obtain the password.
+ *   - JWTs are short-lived (15 min).  Refresh tokens are long-lived (7d),
+ *     rotated on each use, stored hashed.
+ *   - All token hashes are stored in the sessions table for instant revocation.
+ */
+
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { createHash, randomBytes } from 'node:crypto';
+import { z } from 'zod';
+import {
+  createUser, getUserByUsername, getUserById,
+  createSession, revokeSession, revokeAllSessions,
+  getSessionsForUser, revokeSessionById,
+} from '../db/queries/users.js';
+import { hashToken, verifyAuth } from '../middleware/auth.js';
+import { getRedis } from '../plugins/redis.js';
+
+// ---------------------------------------------------------------------------
+// SRP-6a constants  (RFC 3526 — 3072-bit MODP group)
+// ---------------------------------------------------------------------------
+
+// N as a hex string — 3072-bit safe prime from RFC 3526 §2
+const N_HEX =
+  'FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD1' +
+  '29024E088A67CC74020BBEA63B139B22514A08798E3404DD' +
+  'EF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245' +
+  'E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7ED' +
+  'EE386BFB5A899FA5AE9F24117C4B1FE649286651ECE45B3D' +
+  'C2007CB8A163BF0598DA48361C55D39A69163FA8FD24CF5F' +
+  '83655D23DCA3AD961C62F356208552BB9ED529077096966D' +
+  '670C354E4ABC9804F1746C08CA18217C32905E462E36CE3B' +
+  'E39E772C180E86039B2783A2EC07A28FB5C55DF06F4C52C9' +
+  'DE2BCBF6955817183995497CEA956AE515D2261898FA0510' +
+  '15728E5A8AAAC42DAD33170D04507A33A85521ABDF1CBA64' +
+  'ECFB850458DBEF0A8AEA71575D060C7DB3970F85A6E1E4C7' +
+  'ABF5AE8CDB0933D71E8C94E04A25619DCEE3D2261AD2EE6B' +
+  'F12FFA06D98A0864D87602733EC86A64521F2B18177B200C' +
+  'BBE117577A615D6C770988C0BAD946E208E24FA074E5AB31' +
+  '43DB5BFCE0FD108E4B82D120A93AD2CAFFFFFFFFFFFFFFFF';
+
+const N = BigInt('0x' + N_HEX);
+const g = BigInt(2);
+
+// k = H(N | PAD(g))  where PAD pads g to len(N)
+function srpK(): bigint {
+  const nBuf = hexToBuffer(N_HEX);
+  const gBuf = Buffer.alloc(nBuf.length);
+  const gB = bigintToBuffer(g, nBuf.length);
+  gB.copy(gBuf, nBuf.length - gB.length);
+  return bufferToBigint(sha256(Buffer.concat([nBuf, gBuf])));
+}
+const k = srpK();
+
+// ---------------------------------------------------------------------------
+// Crypto helpers
+// ---------------------------------------------------------------------------
+
+function sha256(data: Buffer | string): Buffer {
+  return createHash('sha256').update(data).digest();
+}
+
+function sha256Hex(data: Buffer | string): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+function hexToBuffer(hex: string): Buffer {
+  return Buffer.from(hex.replace(/\s/g, ''), 'hex');
+}
+
+function bufferToHex(buf: Buffer): string {
+  return buf.toString('hex');
+}
+
+function bigintToBuffer(n: bigint, len?: number): Buffer {
+  let hex = n.toString(16);
+  if (hex.length % 2 !== 0) hex = '0' + hex;
+  const buf = Buffer.from(hex, 'hex');
+  if (len && buf.length < len) {
+    const padded = Buffer.alloc(len);
+    buf.copy(padded, len - buf.length);
+    return padded;
+  }
+  return buf;
+}
+
+function bufferToBigint(buf: Buffer): bigint {
+  return BigInt('0x' + bufferToHex(buf));
+}
+
+function modpow(base: bigint, exp: bigint, mod: bigint): bigint {
+  let result = BigInt(1);
+  base = base % mod;
+  while (exp > 0n) {
+    if (exp % 2n === 1n) result = (result * base) % mod;
+    exp = exp / 2n;
+    base = (base * base) % mod;
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// SRP verifier + server-side ephemeral
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the SRP-6a verifier from a salt and x.
+ * x = H(salt | H(username ":" password)) — computed client-side.
+ * v = g^x mod N — stored server-side.
+ *
+ * The server never computes x; it receives v from the client during registration.
+ */
+export function srpVerifierFromHex(vHex: string): Buffer {
+  return hexToBuffer(vHex);
+}
+
+/** Generate server ephemeral key pair: b (secret, random) and B (public). */
+function serverEphemeral(verifier: Buffer): { b: bigint; B: bigint } {
+  const b = bufferToBigint(randomBytes(32));
+  const v = bufferToBigint(verifier);
+  // B = (k*v + g^b) mod N
+  const B = ((k * v % N) + modpow(g, b, N)) % N;
+  return { b, B };
+}
+
+/**
+ * Verify the client proof M1 and compute server proof M2.
+ *
+ * M1 = H( H(N) xor H(g) | H(username) | salt | A | B | K )
+ * K  = H(S)  where S = (A * v^u) ^ b mod N
+ * u  = H(A | B)
+ */
+function verifySrpProof(params: {
+  username: string;
+  salt: Buffer;
+  A: bigint;
+  B: bigint;
+  b: bigint;
+  verifier: Buffer;
+  clientM1: Buffer;
+}): { valid: boolean; M2: Buffer; sessionKey: Buffer } {
+  const { username, salt, A, B, b, verifier, clientM1 } = params;
+  const v = bufferToBigint(verifier);
+  const nLen = bigintToBuffer(N).length;
+
+  // u = H(PAD(A) | PAD(B))
+  const APad = bigintToBuffer(A, nLen);
+  const BPad = bigintToBuffer(B, nLen);
+  const u = bufferToBigint(sha256(Buffer.concat([APad, BPad])));
+
+  // S = (A * v^u mod N) ^ b mod N
+  const S = modpow((A * modpow(v, u, N)) % N, b, N);
+  const K = sha256(bigintToBuffer(S, nLen));
+
+  // H(N) xor H(g)
+  const HN = sha256(bigintToBuffer(N, nLen));
+  const Hg = sha256(bigintToBuffer(g));
+  const HNxorHg = Buffer.alloc(32);
+  for (let i = 0; i < 32; i++) HNxorHg[i] = HN[i] ^ Hg[i];
+
+  // M1 = H( HN^Hg | H(username) | salt | PAD(A) | PAD(B) | K )
+  const Husername = sha256(Buffer.from(username, 'utf8'));
+  const expectedM1 = sha256(Buffer.concat([HNxorHg, Husername, salt, APad, BPad, K]));
+
+  if (!expectedM1.equals(clientM1)) {
+    return { valid: false, M2: Buffer.alloc(0), sessionKey: Buffer.alloc(0) };
+  }
+
+  // M2 = H( PAD(A) | M1 | K )
+  const M2 = sha256(Buffer.concat([APad, clientM1, K]));
+  return { valid: true, M2, sessionKey: K };
+}
+
+// ---------------------------------------------------------------------------
+// JWT helpers
+// ---------------------------------------------------------------------------
+
+function issueTokens(
+  fastify: FastifyInstance,
+  userId: string
+): { accessToken: string; refreshToken: string; accessExpiresAt: Date; refreshExpiresAt: Date } {
+  const accessTtl = process.env.JWT_ACCESS_EXPIRY ?? '15m';
+  const refreshTtl = process.env.JWT_REFRESH_EXPIRY ?? '7d';
+
+  const accessToken = fastify.jwt.sign(
+    { sub: userId },
+    { expiresIn: accessTtl }
+  );
+  const refreshToken = fastify.jwt.sign(
+    { sub: userId, type: 'refresh' },
+    { secret: process.env.JWT_REFRESH_SECRET ?? 'changeme-refresh',
+      expiresIn: refreshTtl }
+  );
+
+  const accessMs = accessTtl.endsWith('m')
+    ? parseInt(accessTtl) * 60_000
+    : parseInt(accessTtl) * 1000;
+  const refreshMs = refreshTtl.endsWith('d')
+    ? parseInt(refreshTtl) * 86_400_000
+    : 604_800_000;
+
+  return {
+    accessToken,
+    refreshToken,
+    accessExpiresAt: new Date(Date.now() + accessMs),
+    refreshExpiresAt: new Date(Date.now() + refreshMs),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Zod schemas
+// ---------------------------------------------------------------------------
+
+const RegisterSchema = z.object({
+  username:     z.string().min(3).max(32).regex(/^[a-zA-Z0-9_-]+$/),
+  srpSalt:      z.string().min(64).max(64),      // 32 bytes hex
+  srpVerifier:  z.string().min(1).max(2048),      // hex bigint
+  encryptedDek: z.string().min(1),               // JSON { iv, ct }
+  dekSalt:      z.string().min(64).max(64),       // 32 bytes hex
+});
+
+const LoginInitSchema  = z.object({ username: z.string().min(1) });
+
+const LoginVerifySchema = z.object({
+  username:   z.string().min(1),
+  clientA:    z.string().min(1),   // A hex
+  clientM1:   z.string().min(1),   // M1 hex
+});
+
+// ---------------------------------------------------------------------------
+// Route plugin
+// ---------------------------------------------------------------------------
+
+export default async function authRoutes(fastify: FastifyInstance): Promise<void> {
+  const redis = await getRedis();
+
+  // ── Register ─────────────────────────────────────────────────────────────
+
+  fastify.post('/api/auth/register', async (req: FastifyRequest, reply: FastifyReply) => {
+    const parse = RegisterSchema.safeParse(req.body);
+    if (!parse.success) return reply.code(400).send({ error: 'Invalid request', details: parse.error.flatten() });
+    const { username, srpSalt, srpVerifier, encryptedDek, dekSalt } = parse.data;
+
+    // Check uniqueness
+    const existing = await getUserByUsername(username);
+    if (existing) return reply.code(409).send({ error: 'Username already taken' });
+
+    await createUser({
+      username,
+      srpSalt:     Buffer.from(srpSalt, 'hex'),
+      srpVerifier: Buffer.from(srpVerifier, 'hex'),
+      encryptedDek,
+      dekSalt:     Buffer.from(dekSalt, 'hex'),
+    });
+
+    return reply.code(201).send({ ok: true });
+  });
+
+  // ── Login step 1: client sends username → server returns salt + B ────────
+
+  fastify.post('/api/auth/login/init', async (req: FastifyRequest, reply: FastifyReply) => {
+    const parse = LoginInitSchema.safeParse(req.body);
+    if (!parse.success) return reply.code(400).send({ error: 'Invalid request' });
+    const { username } = parse.data;
+
+    const user = await getUserByUsername(username);
+    // Return a fake response for unknown users to prevent user enumeration
+    if (!user) {
+      const fakeSalt = randomBytes(32).toString('hex');
+      const fakeB    = randomBytes(384).toString('hex');
+      return reply.code(200).send({ srpSalt: fakeSalt, serverB: fakeB });
+    }
+
+    const { b, B } = serverEphemeral(user.srp_verifier);
+    const serverBHex = bigintToBuffer(B).toString('hex');
+
+    // Store server ephemeral secret in Redis with 120s TTL
+    const challengeKey = `srp:${sha256Hex(username)}`;
+    await redis.setEx(
+      challengeKey,
+      120,
+      JSON.stringify({ b: b.toString(16), userId: user.id })
+    );
+
+    return reply.code(200).send({
+      srpSalt:  user.srp_salt.toString('hex'),
+      serverB:  serverBHex,
+    });
+  });
+
+  // ── Login step 2: client sends A + M1 → server verifies + issues JWT ────
+
+  fastify.post('/api/auth/login/verify', async (req: FastifyRequest, reply: FastifyReply) => {
+    const parse = LoginVerifySchema.safeParse(req.body);
+    if (!parse.success) return reply.code(400).send({ error: 'Invalid request' });
+    const { username, clientA, clientM1 } = parse.data;
+
+    // Retrieve ephemeral from Redis
+    const challengeKey = `srp:${sha256Hex(username)}`;
+    const stored = await redis.get(challengeKey);
+    if (!stored) return reply.code(401).send({ error: 'Login session expired. Please retry.' });
+
+    const { b: bHex, userId } = JSON.parse(stored) as { b: string; userId: string };
+    await redis.del(challengeKey);  // one-time use
+
+    const user = await getUserById(userId);
+    if (!user) return reply.code(401).send({ error: 'Unauthorized' });
+
+    const A = BigInt('0x' + clientA);
+    // A must not be 0 mod N (SRP spec §6)
+    if (A % N === 0n) return reply.code(401).send({ error: 'Invalid client key' });
+
+    // Re-derive B to verify (we only stored b; recompute B from b and verifier)
+    const b = BigInt('0x' + bHex);
+    const v = bufferToBigint(user.srp_verifier);
+    const B = ((k * v % N) + modpow(g, b, N)) % N;
+
+    const { valid, M2 } = verifySrpProof({
+      username,
+      salt:      user.srp_salt,
+      A,
+      B,
+      b,
+      verifier:  user.srp_verifier,
+      clientM1:  Buffer.from(clientM1, 'hex'),
+    });
+
+    if (!valid) return reply.code(401).send({ error: 'Authentication failed' });
+
+    // Issue JWTs
+    const { accessToken, refreshToken, accessExpiresAt, refreshExpiresAt } = issueTokens(fastify, userId);
+    const deviceInfo = ((req.headers['user-agent'] as string) ?? '').slice(0, 200);
+
+    // Store hashed access token for revocation checks
+    await createSession({
+      userId,
+      tokenHash:  hashToken(accessToken),
+      deviceInfo: deviceInfo || null,
+      expiresAt:  accessExpiresAt,
+    });
+
+    // Refresh token stored in httpOnly cookie (never accessible to JS)
+    reply.setCookie('bedroc_refresh', refreshToken, {
+      httpOnly: true,
+      secure:   process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+      path:     '/api/auth/refresh',
+      maxAge:   7 * 24 * 3600,
+    });
+
+    return reply.code(200).send({
+      accessToken,
+      expiresAt:    accessExpiresAt.toISOString(),
+      encryptedDek: user.encrypted_dek,
+      dekSalt:      user.dek_salt.toString('hex'),
+      serverM2:     M2.toString('hex'),
+    });
+  });
+
+  // ── Refresh access token ─────────────────────────────────────────────────
+
+  fastify.post('/api/auth/refresh', async (req: FastifyRequest, reply: FastifyReply) => {
+    const refreshToken = req.cookies?.bedroc_refresh;
+    if (!refreshToken) return reply.code(401).send({ error: 'No refresh token' });
+
+    let payload: { sub: string; type?: string };
+    try {
+      payload = fastify.jwt.verify(refreshToken, {
+        key: process.env.JWT_REFRESH_SECRET ?? 'changeme-refresh',
+      }) as { sub: string; type?: string };
+    } catch {
+      return reply.code(401).send({ error: 'Invalid refresh token' });
+    }
+
+    if (payload.type !== 'refresh') return reply.code(401).send({ error: 'Invalid token type' });
+
+    const user = await getUserById(payload.sub);
+    if (!user) return reply.code(401).send({ error: 'User not found' });
+
+    const { accessToken, refreshToken: newRefresh, accessExpiresAt } = issueTokens(fastify, user.id);
+
+    await createSession({
+      userId:    user.id,
+      tokenHash: hashToken(accessToken),
+      deviceInfo: null,
+      expiresAt:  accessExpiresAt,
+    });
+
+    reply.setCookie('bedroc_refresh', newRefresh, {
+      httpOnly: true,
+      secure:   process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+      path:     '/api/auth/refresh',
+      maxAge:   7 * 24 * 3600,
+    });
+
+    return reply.code(200).send({ accessToken, expiresAt: accessExpiresAt.toISOString() });
+  });
+
+  // ── Logout ───────────────────────────────────────────────────────────────
+
+  fastify.post('/api/auth/logout', async (req: FastifyRequest, reply: FastifyReply) => {
+    // Best-effort: revoke even without full auth to handle expired tokens
+    const authHeader = req.headers.authorization ?? '';
+    const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null;
+    if (token) await revokeSession(hashToken(token));
+
+    reply.clearCookie('bedroc_refresh', { path: '/api/auth/refresh' });
+    return reply.code(200).send({ ok: true });
+  });
+
+  // ── Sessions list (protected) ────────────────────────────────────────────
+
+  fastify.get('/api/auth/sessions', async (req: FastifyRequest, reply: FastifyReply) => {
+    await verifyAuth(req, reply);
+    if (reply.sent) return;
+    const userId = (req as FastifyRequest & { userId: string }).userId;
+    const sessions = await getSessionsForUser(userId);
+    return reply.code(200).send({ sessions });
+  });
+
+  // ── Revoke a specific session (protected) ───────────────────────────────
+
+  fastify.delete('/api/auth/sessions/:id', async (req: FastifyRequest, reply: FastifyReply) => {
+    await verifyAuth(req, reply);
+    if (reply.sent) return;
+    const userId = (req as FastifyRequest & { userId: string }).userId;
+    const { id } = req.params as { id: string };
+    await revokeSessionById(id, userId);
+    return reply.code(200).send({ ok: true });
+  });
+
+  // ── Revoke all sessions (logout everywhere) (protected) ─────────────────
+
+  fastify.post('/api/auth/sessions/revoke-all', async (req: FastifyRequest, reply: FastifyReply) => {
+    await verifyAuth(req, reply);
+    if (reply.sent) return;
+    const userId = (req as FastifyRequest & { userId: string }).userId;
+    await revokeAllSessions(userId);
+    reply.clearCookie('bedroc_refresh', { path: '/api/auth/refresh' });
+    return reply.code(200).send({ ok: true });
+  });
+
+  // ── Delete account (protected) ───────────────────────────────────────────
+  // Deletes the user row; CASCADE removes all sessions, notes, topics, folders.
+
+  fastify.delete('/api/auth/account', async (req: FastifyRequest, reply: FastifyReply) => {
+    await verifyAuth(req, reply);
+    if (reply.sent) return;
+    const userId = (req as FastifyRequest & { userId: string }).userId;
+    // Imported lazily to avoid circular dep
+    const { deleteUser } = await import('../db/queries/users.js');
+    await deleteUser(userId);
+    reply.clearCookie('bedroc_refresh', { path: '/api/auth/refresh' });
+    return reply.code(200).send({ ok: true });
+  });
+}

--- a/server/src/routes/notes.ts
+++ b/server/src/routes/notes.ts
@@ -1,0 +1,184 @@
+/**
+ * routes/notes.ts — Encrypted note CRUD, topic/folder CRUD, and delta sync.
+ *
+ * All note content (title, body) is AES-256-GCM ciphertext from the client.
+ * The server stores and returns blobs without inspection.
+ *
+ * Topics and folders store plaintext metadata (name, color, order) because
+ * they are not sensitive — they are just labels visible in the sidebar.
+ * A future version could encrypt topic/folder names if desired.
+ */
+
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { z } from 'zod';
+import { verifyAuth } from '../middleware/auth.js';
+import {
+  upsertNote, getNoteById, getNotesByUser, getNotesSince, softDeleteNote,
+  upsertTopic, getTopicsByUser, deleteTopic,
+  upsertFolder, getFoldersByUser, deleteFolder,
+} from '../db/queries/notes.js';
+import { notifyClients } from './sync.js';
+
+// ---------------------------------------------------------------------------
+// Zod schemas — validate incoming shapes without trusting the client
+// ---------------------------------------------------------------------------
+
+const NoteUpsertSchema = z.object({
+  id:               z.string().uuid(),
+  topicId:          z.string().uuid().nullable(),
+  encryptedTitle:   z.string().min(1),     // JSON { iv, ct }
+  encryptedBody:    z.string().min(1),     // JSON { iv, ct }
+  customOrder:      z.number().int().min(0),
+  clientUpdatedAt:  z.string().datetime(),
+  version:          z.number().int().min(1),
+});
+
+const TopicUpsertSchema = z.object({
+  id:        z.string().uuid(),
+  name:      z.string().min(1).max(80),
+  color:     z.string().regex(/^#[0-9a-fA-F]{6}$/),
+  folderId:  z.string().uuid().nullable(),
+  sortOrder: z.number().int().min(0),
+});
+
+const FolderUpsertSchema = z.object({
+  id:        z.string().uuid(),
+  name:      z.string().min(1).max(80),
+  parentId:  z.string().uuid().nullable(),
+  sortOrder: z.number().int().min(0),
+  collapsed: z.boolean(),
+});
+
+// ---------------------------------------------------------------------------
+// Helper: extract verified userId from request
+// ---------------------------------------------------------------------------
+
+function uid(req: FastifyRequest): string {
+  return (req as FastifyRequest & { userId: string }).userId;
+}
+
+// ---------------------------------------------------------------------------
+// Route plugin
+// ---------------------------------------------------------------------------
+
+export default async function notesRoutes(fastify: FastifyInstance): Promise<void> {
+
+  // ── GET /api/notes — list all notes for the authenticated user ───────────
+  fastify.get('/api/notes', async (req: FastifyRequest, reply: FastifyReply) => {
+    await verifyAuth(req, reply);
+    if (reply.sent) return;
+    const notes = await getNotesByUser(uid(req));
+    return reply.code(200).send({ notes });
+  });
+
+  // ── GET /api/notes/sync?since=ISO — delta sync ───────────────────────────
+  fastify.get('/api/notes/sync', async (req: FastifyRequest, reply: FastifyReply) => {
+    await verifyAuth(req, reply);
+    if (reply.sent) return;
+    const { since } = req.query as { since?: string };
+    const sinceDate = since ? new Date(since) : new Date(0);
+    if (isNaN(sinceDate.getTime())) return reply.code(400).send({ error: 'Invalid since parameter' });
+    const notes = await getNotesSince(uid(req), sinceDate);
+    return reply.code(200).send({ notes, serverTime: new Date().toISOString() });
+  });
+
+  // ── GET /api/notes/:id — fetch a single note ─────────────────────────────
+  fastify.get('/api/notes/:id', async (req: FastifyRequest, reply: FastifyReply) => {
+    await verifyAuth(req, reply);
+    if (reply.sent) return;
+    const { id } = req.params as { id: string };
+    const note = await getNoteById(id, uid(req));
+    if (!note) return reply.code(404).send({ error: 'Not found' });
+    return reply.code(200).send({ note });
+  });
+
+  // ── PUT /api/notes/:id — upsert (create or update) ───────────────────────
+  fastify.put('/api/notes/:id', async (req: FastifyRequest, reply: FastifyReply) => {
+    await verifyAuth(req, reply);
+    if (reply.sent) return;
+    const { id } = req.params as { id: string };
+    const body = { ...(req.body as object), id };
+    const parse = NoteUpsertSchema.safeParse(body);
+    if (!parse.success) return reply.code(400).send({ error: 'Invalid note', details: parse.error.flatten() });
+
+    const note = await upsertNote({
+      ...parse.data,
+      userId:         uid(req),
+      topicId:        parse.data.topicId,
+      encryptedTitle: parse.data.encryptedTitle,
+      encryptedBody:  parse.data.encryptedBody,
+      clientUpdatedAt: new Date(parse.data.clientUpdatedAt),
+    });
+
+    // Push real-time notification to other connected sessions for this user
+    await notifyClients(uid(req), { type: 'note:updated', noteId: id });
+
+    return reply.code(200).send({ note });
+  });
+
+  // ── DELETE /api/notes/:id — soft delete ──────────────────────────────────
+  fastify.delete('/api/notes/:id', async (req: FastifyRequest, reply: FastifyReply) => {
+    await verifyAuth(req, reply);
+    if (reply.sent) return;
+    const { id } = req.params as { id: string };
+    await softDeleteNote(id, uid(req));
+    await notifyClients(uid(req), { type: 'note:deleted', noteId: id });
+    return reply.code(200).send({ ok: true });
+  });
+
+  // ── GET /api/topics ───────────────────────────────────────────────────────
+  fastify.get('/api/topics', async (req: FastifyRequest, reply: FastifyReply) => {
+    await verifyAuth(req, reply);
+    if (reply.sent) return;
+    const topics = await getTopicsByUser(uid(req));
+    return reply.code(200).send({ topics });
+  });
+
+  // ── PUT /api/topics/:id ───────────────────────────────────────────────────
+  fastify.put('/api/topics/:id', async (req: FastifyRequest, reply: FastifyReply) => {
+    await verifyAuth(req, reply);
+    if (reply.sent) return;
+    const { id } = req.params as { id: string };
+    const parse = TopicUpsertSchema.safeParse({ ...(req.body as object), id });
+    if (!parse.success) return reply.code(400).send({ error: 'Invalid topic' });
+    const topic = await upsertTopic({ ...parse.data, userId: uid(req) });
+    return reply.code(200).send({ topic });
+  });
+
+  // ── DELETE /api/topics/:id ────────────────────────────────────────────────
+  fastify.delete('/api/topics/:id', async (req: FastifyRequest, reply: FastifyReply) => {
+    await verifyAuth(req, reply);
+    if (reply.sent) return;
+    const { id } = req.params as { id: string };
+    await deleteTopic(id, uid(req));
+    return reply.code(200).send({ ok: true });
+  });
+
+  // ── GET /api/folders ──────────────────────────────────────────────────────
+  fastify.get('/api/folders', async (req: FastifyRequest, reply: FastifyReply) => {
+    await verifyAuth(req, reply);
+    if (reply.sent) return;
+    const folders = await getFoldersByUser(uid(req));
+    return reply.code(200).send({ folders });
+  });
+
+  // ── PUT /api/folders/:id ──────────────────────────────────────────────────
+  fastify.put('/api/folders/:id', async (req: FastifyRequest, reply: FastifyReply) => {
+    await verifyAuth(req, reply);
+    if (reply.sent) return;
+    const { id } = req.params as { id: string };
+    const parse = FolderUpsertSchema.safeParse({ ...(req.body as object), id });
+    if (!parse.success) return reply.code(400).send({ error: 'Invalid folder' });
+    const folder = await upsertFolder({ ...parse.data, userId: uid(req) });
+    return reply.code(200).send({ folder });
+  });
+
+  // ── DELETE /api/folders/:id ───────────────────────────────────────────────
+  fastify.delete('/api/folders/:id', async (req: FastifyRequest, reply: FastifyReply) => {
+    await verifyAuth(req, reply);
+    if (reply.sent) return;
+    const { id } = req.params as { id: string };
+    await deleteFolder(id, uid(req));
+    return reply.code(200).send({ ok: true });
+  });
+}

--- a/server/src/routes/sync.ts
+++ b/server/src/routes/sync.ts
@@ -1,0 +1,118 @@
+/**
+ * routes/sync.ts — WebSocket real-time sync.
+ *
+ * Each authenticated WebSocket connection is tracked in a per-user set.
+ * When any note is saved/deleted via REST, `notifyClients(userId, msg)` fans
+ * out the event to all other connections for that user (multi-device sync).
+ *
+ * Message protocol (all JSON):
+ *   Server → Client:
+ *     { type: 'note:updated', noteId: string }
+ *     { type: 'note:deleted', noteId: string }
+ *     { type: 'pong' }
+ *   Client → Server:
+ *     { type: 'ping' }
+ *
+ * Authentication: client sends the access JWT in the `Authorization` query
+ * parameter on the WebSocket handshake URL, e.g.:
+ *   wss://host/ws?token=<access_token>
+ *
+ * The token is verified before the connection is accepted.
+ */
+
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import type { WebSocket } from 'ws';
+import { verifyAuth } from '../middleware/auth.js';
+
+// ---------------------------------------------------------------------------
+// In-process connection registry  (userId → Set<WebSocket>)
+// ---------------------------------------------------------------------------
+// For a multi-instance deployment, replace this with Redis pub/sub:
+//   - On notifyClients(), PUBLISH to a Redis channel for that userId.
+//   - Each server instance SUBSCRIBES to all user channels for its connected clients.
+
+const connections = new Map<string, Set<WebSocket>>();
+
+function register(userId: string, ws: WebSocket): void {
+  if (!connections.has(userId)) connections.set(userId, new Set());
+  connections.get(userId)!.add(ws);
+}
+
+function unregister(userId: string, ws: WebSocket): void {
+  const set = connections.get(userId);
+  if (!set) return;
+  set.delete(ws);
+  if (set.size === 0) connections.delete(userId);
+}
+
+/**
+ * Notify all *other* WebSocket connections for a given user of a note change.
+ * Used by REST note handlers after a successful save/delete.
+ */
+export async function notifyClients(
+  userId: string,
+  message: { type: string; noteId: string }
+): Promise<void> {
+  const set = connections.get(userId);
+  if (!set) return;
+  const json = JSON.stringify(message);
+  for (const ws of set) {
+    if (ws.readyState === 1 /* OPEN */) {
+      ws.send(json);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket route plugin
+// ---------------------------------------------------------------------------
+
+export default async function syncRoutes(fastify: FastifyInstance): Promise<void> {
+  fastify.get('/ws', { websocket: true }, async (socket: WebSocket, req: FastifyRequest) => {
+    // Extract token from query param (WebSocket handshake cannot send headers in browser)
+    const token = (req.query as Record<string, string>).token;
+    if (!token) {
+      socket.close(4001, 'Missing token');
+      return;
+    }
+
+    // Temporarily set the Authorization header for verifyAuth reuse
+    (req.headers as Record<string, string>).authorization = `Bearer ${token}`;
+
+    // Fake reply object to detect auth failure
+    let authed = true;
+    const fakeReply = {
+      code: () => fakeReply,
+      send: () => { authed = false; },
+      sent: false,
+    } as unknown as import('fastify').FastifyReply;
+
+    await verifyAuth(req, fakeReply);
+    if (!authed) {
+      socket.close(4001, 'Unauthorized');
+      return;
+    }
+
+    const userId = (req as FastifyRequest & { userId: string }).userId;
+    register(userId, socket);
+
+    socket.on('message', (raw: Buffer | string) => {
+      try {
+        const msg = JSON.parse(raw.toString()) as { type: string };
+        if (msg.type === 'ping') {
+          socket.send(JSON.stringify({ type: 'pong' }));
+        }
+      } catch {
+        // ignore malformed messages
+      }
+    });
+
+    socket.on('close', () => {
+      unregister(userId, socket);
+    });
+
+    socket.on('error', () => {
+      unregister(userId, socket);
+    });
+  });
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Introduce a full self-hosting stack and client crypto/storage. Adds server code (routes, DB queries, migrations, auth middleware, Redis plugin), Dockerfiles and docker-compose for running the backend, Postgres and nginx, and a SvelteKit static frontend Dockerfile. On the frontend side add end-to-end crypto (keys, AES-GCM encrypt/decrypt, SRP client) and an IndexedDB offline storage layer plus updates to stores and routes. Also include a .env.example, GUIDE.md for deployment, and .gitignore updates. This prepares the project for private self-hosting with client-side encryption and offline sync.