### PR TITLE
Handle sync conflicts, password change, WS client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,20 @@ JWT_ACCESS_EXPIRY=15m
 JWT_REFRESH_EXPIRY=7d
 
 # ── CORS ──────────────────────────────────────────────────────────────────────
-# The origin of the frontend. Must match exactly (no trailing slash).
-# For WireGuard-only access, this is the WireGuard IP:
-CORS_ORIGIN=https://10.66.66.1
-# If you use a domain: CORS_ORIGIN=https://notes.yourdomain.com
+# Controls which frontend origins are allowed to make API requests.
+#
+# Option 1 — Strict (recommended for personal/private servers):
+#   Allow only one specific frontend origin. Anyone using the public Bedroc
+#   website or a different frontend URL will be blocked by CORS.
+#   CORS_ORIGIN=https://10.66.66.1               # WireGuard IP
+#   CORS_ORIGIN=https://notes.yourdomain.com      # your domain
+#   CORS_ORIGIN=https://bedroc.cagancalidag.com   # public hosted frontend
+#
+# Option 2 — Open (recommended for public self-hosting):
+#   Allow any origin. Users can point the public Bedroc website OR their own
+#   Bedroc instance at your server. Security is enforced by JWT auth, not CORS.
+#   Unset or empty = allow any origin.
+#   CORS_ORIGIN=
+#
+# Default below allows any origin (open model — works with the public frontend).
+CORS_ORIGIN=

--- a/DEV-GUIDE.md
+++ b/DEV-GUIDE.md
@@ -1,0 +1,377 @@
+# Bedroc — Developer & Contributor Guide
+
+This guide is for developers who want to build, fork, modify, or deploy Bedroc from source.
+
+---
+
+## Repository layout
+
+```text
+Bedroc/
+├── bedroc/          SvelteKit frontend (TypeScript, Svelte 5, TailwindCSS)
+│   ├── src/
+│   │   ├── lib/
+│   │   │   ├── crypto/      WebCrypto wrappers (PBKDF2, AES-GCM, SRP-6a)
+│   │   │   ├── db/          IndexedDB offline layer
+│   │   │   ├── sync/        WebSocket client (websocket.ts)
+│   │   │   └── stores/      Svelte 5 rune-based state (auth, notes)
+│   │   └── routes/          SvelteKit pages (+page.svelte)
+│   ├── static/              PWA icons, manifest, sw.js (service worker)
+│   ├── Dockerfile           Multi-stage: Node build → nginx static serve
+│   ├── nginx-static.conf    nginx config inside the bedroc container
+│   └── vercel.json          SPA rewrite rule for Vercel deployment
+│
+├── server/          Fastify backend (TypeScript, Node 22)
+│   ├── src/
+│   │   ├── db/
+│   │   │   ├── client.ts        pg pool + migration runner
+│   │   │   ├── migrations/      SQL migration files (001_init.sql, …)
+│   │   │   └── queries/         Typed pg query functions
+│   │   ├── middleware/auth.ts   JWT verification helper
+│   │   ├── plugins/redis.ts     Redis singleton
+│   │   └── routes/
+│   │       ├── auth.ts          Register, SRP login, logout, sessions, change-password
+│   │       ├── notes.ts         CRUD for notes, topics, folders
+│   │       └── sync.ts          WebSocket real-time sync
+│   └── Dockerfile
+│
+├── docker/
+│   ├── nginx/nginx.conf     Outer reverse proxy (TLS termination, WireGuard bind)
+│   ├── nginx-static.conf    (canonical copy — also copied to bedroc/)
+│   ├── postgres/init.sql    First-boot DB user + permissions
+│   └── ssl/                 TLS certs (git-ignored)
+│
+├── docker-compose.yml       Production stack
+├── .env.example             All required env vars with documentation
+├── GUIDE.md                 End-user self-hosting guide
+└── DEV-GUIDE.md             This file
+```
+
+---
+
+## Running locally for development
+
+### Prerequisites
+
+- Node.js 22+
+- Docker + Docker Compose (for postgres + redis)
+- `openssl` (for generating dev SSL cert)
+
+### 1. Start backing services
+
+```bash
+# From repo root — starts postgres and redis only
+docker compose up -d postgres redis
+```
+
+### 2. Run the backend
+
+```bash
+cd server
+npm install
+
+# Create a dev .env (copy and fill in)
+cp ../.env.example .env
+# Edit .env: set DATABASE_URL, REDIS_URL, JWT secrets
+# For dev, you can use:
+#   HOST=0.0.0.0
+#   DATABASE_URL=postgres://bedroc_app:devpassword@localhost:5432/bedroc
+#   REDIS_URL=redis://localhost:6379
+#   JWT_ACCESS_SECRET=dev-access-secret-at-least-32-chars
+#   JWT_REFRESH_SECRET=dev-refresh-secret-at-least-32-chars
+
+npm run dev
+# Server starts on http://localhost:3000
+```
+
+### 3. Run the frontend
+
+```bash
+cd bedroc
+npm install
+npm run dev
+# Frontend starts on http://localhost:5173
+```
+
+Open `http://localhost:5173`, tap "Server" on the login page, and enter `http://localhost:3000`.
+
+---
+
+## Building for production
+
+### Frontend (static SPA)
+
+```bash
+cd bedroc
+npm run build
+# Output: bedroc/build/
+```
+
+The output is a plain static site — serve it from any static host (Vercel, nginx, S3+CloudFront, etc.).
+
+### Backend (Docker)
+
+```bash
+# From repo root
+docker compose build server
+```
+
+Or build and push manually:
+
+```bash
+cd server
+docker build -t your-registry/bedroc-server:latest .
+docker push your-registry/bedroc-server:latest
+```
+
+### Full stack
+
+```bash
+# From repo root
+cp .env.example .env
+# Fill in .env
+docker compose up -d --build
+```
+
+---
+
+## Deploying the frontend to Vercel
+
+The frontend is a static SPA — deploy it to Vercel by connecting the repo and setting:
+
+- **Root directory:** `bedroc`
+- **Build command:** `npm run build`
+- **Output directory:** `build`
+- **Install command:** `npm install`
+
+The `vercel.json` in `bedroc/` handles SPA routing (all paths → `index.html`).
+
+No environment variables are needed on Vercel — the frontend is fully client-side and connects to whichever backend URL the user provides at login.
+
+---
+
+## Deploying the frontend to a custom domain (nginx)
+
+After `npm run build`, copy `bedroc/build/` to your server and serve with nginx:
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name notes.yourdomain.com;
+    ssl_certificate     /path/to/cert.pem;
+    ssl_certificate_key /path/to/key.pem;
+
+    root /var/www/bedroc;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+```
+
+---
+
+## Security checklist before going public
+
+These values **must** be changed from their defaults before running in production:
+
+| What | Where | How |
+| --- | --- | --- |
+| `JWT_ACCESS_SECRET` | `.env` | `openssl rand -hex 32` |
+| `JWT_REFRESH_SECRET` | `.env` | `openssl rand -hex 32` (different from above) |
+| `POSTGRES_PASSWORD` | `.env` | Strong random password |
+| `DATABASE_URL` password | `.env` | Must match `POSTGRES_PASSWORD` |
+| TLS certificate | `docker/ssl/cert.pem` + `key.pem` | Self-signed (WireGuard) or Let's Encrypt (public) |
+
+Run this twice to get two different secrets:
+
+```bash
+openssl rand -hex 32
+```
+
+Never commit `.env` to git. It is listed in `.gitignore`.
+
+---
+
+## Database migrations
+
+Migrations run automatically on every server startup (`runMigrations()` in `server/src/db/client.ts`). They are idempotent — safe to run multiple times.
+
+Migration files live at `server/src/db/migrations/` and are numbered sequentially:
+
+```text
+001_init.sql   — users, sessions, notes, topics, folders tables
+002_*.sql      — (future migrations)
+```
+
+To add a migration:
+
+1. Create `server/src/db/migrations/002_description.sql`
+2. The migration runner automatically picks up new files on next restart
+
+To run migrations manually (e.g. for inspection):
+
+```bash
+docker compose exec postgres psql -U postgres -d bedroc -f /path/to/migration.sql
+```
+
+---
+
+## Architecture overview
+
+### End-to-end encryption model
+
+```text
+User password
+  └─ PBKDF2(password, dekSalt, 600k rounds, SHA-256)
+        └─ Master Key (AES-256, never stored)
+              └─ AES-GCM.decrypt(encryptedDek)
+                    └─ DEK — Data Encryption Key (in memory only)
+                          └─ AES-GCM.encrypt(note title + body)
+                                └─ Ciphertext (stored on server)
+```
+
+- The server stores `encrypted_dek` (DEK wrapped with Master Key) and `dek_salt`.
+- The server **cannot** decrypt notes — it never sees the plaintext DEK or Master Key.
+- If the user forgets their password, their data is permanently inaccessible — by design.
+
+### Authentication (SRP-6a)
+
+The password is **never sent to the server** in any form. SRP-6a lets the client prove knowledge of the password using zero-knowledge cryptography. See `server/src/routes/auth.ts` and `bedroc/src/lib/crypto/srp.ts` for the implementation.
+
+Key properties:
+
+- Server stores only an SRP verifier (cannot be used to log in or reverse the password)
+- Mutual authentication: both client and server prove they know the password
+- Implemented with the 3072-bit MODP group (RFC 3526) — no external SRP libraries
+
+### Offline-first data flow
+
+```text
+Write:
+  1. Encrypt (client)
+  2. Write to IndexedDB (instant, works offline)
+  3. Enqueue to syncQueue in IndexedDB
+  4. Attempt server PUT (if online)
+  5. On success: mark synced, dequeue
+  6. On failure: leave in queue, retry on next flush
+
+Read:
+  1. Load from IndexedDB (instant)
+  2. Delta sync from server (notes updated since last sync)
+  3. Decrypt + merge into reactive store
+  4. Conflict detection: if local has unsynced edits AND server is newer → store conflict, preserve local
+```
+
+### API routes
+
+All endpoints are at `/api/...`.
+
+| Method | Path | Auth | Description |
+| --- | --- | --- | --- |
+| `GET` | `/health` | None | Health check |
+| `POST` | `/api/auth/register` | None | Create account |
+| `POST` | `/api/auth/login/init` | None | SRP step 1 |
+| `POST` | `/api/auth/login/verify` | None | SRP step 2 + issue JWT |
+| `POST` | `/api/auth/refresh` | Cookie | Refresh access token |
+| `POST` | `/api/auth/logout` | JWT | Revoke session |
+| `POST` | `/api/auth/change-password` | JWT | Change password + re-encrypt DEK |
+| `GET` | `/api/auth/sessions` | JWT | List active sessions |
+| `DELETE` | `/api/auth/sessions/:id` | JWT | Revoke specific session |
+| `POST` | `/api/auth/sessions/revoke-all` | JWT | Revoke all sessions |
+| `DELETE` | `/api/auth/account` | JWT | Delete account + all data |
+| `GET` | `/api/notes` | JWT | Get all notes (encrypted) |
+| `GET` | `/api/notes/sync` | JWT | Delta sync (notes updated since timestamp) |
+| `PUT` | `/api/notes/:id` | JWT | Create/update note |
+| `DELETE` | `/api/notes/:id` | JWT | Delete note |
+| `GET` | `/api/topics` | JWT | Get all topics |
+| `PUT` | `/api/topics/:id` | JWT | Create/update topic |
+| `DELETE` | `/api/topics/:id` | JWT | Delete topic |
+| `GET` | `/api/folders` | JWT | Get all folders |
+| `PUT` | `/api/folders/:id` | JWT | Create/update folder |
+| `DELETE` | `/api/folders/:id` | JWT | Delete folder |
+| `GET` | `/ws` | JWT (query param) | WebSocket real-time sync |
+
+---
+
+## Frontend deployment model
+
+Bedroc uses a **"public frontend, self-hosted backend"** model:
+
+- The frontend (this repo's `bedroc/` directory) is stateless — it has no server-side component.
+- It can be hosted anywhere: Vercel, GitHub Pages, nginx, Electron, etc.
+- At login/register, the user specifies their backend URL (defaults to `https://api.bedroc.app`).
+- The backend URL is saved to localStorage so users don't re-enter it.
+
+This means:
+
+- Users who want privacy can point the public frontend at their own backend.
+- Self-hosters only need to run the backend stack — they can use the public frontend.
+- The frontend URL is irrelevant to security — all data security is in the encryption layer.
+
+### CORS on the backend
+
+`CORS_ORIGIN` in `.env` controls this:
+
+- Empty/unset → accept any origin (recommended for public self-hosting)
+- Specific URL → restrict to that frontend only (recommended for private servers)
+
+---
+
+## Real-time sync (WebSocket)
+
+Multi-device real-time sync is implemented end-to-end:
+
+- **Server** (`server/src/routes/sync.ts`): WebSocket route at `GET /ws`. JWT auth via `?token=` query param. Broadcasts `note:updated` / `note:deleted` messages to all other connections for the same user.
+- **Client** (`bedroc/src/lib/sync/websocket.ts`): connects on login, disconnects on logout. Auto-reconnects with exponential backoff (1s → 2s → 4s → … → 60s max). Sends a keepalive ping every 30s. Wired into `+layout.svelte` via `wsConnect()` / `wsDisconnect()`.
+- **On message**: `note:updated` or `note:deleted` triggers `syncFromServer()`, which pulls and merges the delta from the server.
+
+---
+
+## Offline / PWA
+
+A service worker (`bedroc/static/sw.js`) caches the app shell for true offline use:
+
+- **Static assets** (JS, CSS, icons): cache-first, updated in background.
+- **Navigation** (HTML): network-first, falls back to the cached SPA shell (`/`). SvelteKit handles routing client-side.
+- **API / WS**: never cached — always network-only.
+- Registered in `+layout.svelte` on mount. Works on iOS Safari 11.3+, Android, all desktop browsers.
+
+---
+
+## Offline conflict resolution
+
+When a note is edited offline on one device and also updated on the server (from another device), a conflict is detected on next sync:
+
+- **Conflict condition**: `synced: false` AND `clientUpdatedAt > serverUpdatedAt` AND server has a newer `server_updated_at`.
+- **Conflict stored**: both the local and server versions are saved to the `conflicts` IndexedDB object store (DB version 2). The local note is **never silently overwritten**.
+- **Resolution UI**: a banner appears on the note editor when a conflict is detected. The user can expand it to see both versions side-by-side and choose: keep local, keep server, or write a custom merge.
+- **After resolution**: the chosen version is saved locally, pushed to the server, and the conflict record is deleted.
+
+---
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch: `git checkout -b feature/my-feature`
+3. Make your changes
+4. Run type-check: `cd bedroc && npm run check`
+5. Open a pull request against `main`
+
+### Keeping docs updated
+
+When making changes:
+
+- Update `GUIDE.md` if the self-hosting process changes (env vars, ports, Docker config)
+- Update `DEV-GUIDE.md` if the architecture, API, or build process changes
+- Update `docs/PLACEHOLDERS.md` when implementing a placeholder feature
+
+---
+
+## Known limitations (current state)
+
+- **Change password** re-derives master key and re-wraps the DEK, but does not revoke existing sessions. Users who want to invalidate all sessions after a password change should also use "Revoke all sessions" in Settings.
+- **Rate limiting** on auth routes uses Redis — if Redis is unavailable, the rate limiter falls back to in-memory (single-instance only).
+- **iOS push notifications**: the PWA service worker does not support push notifications on iOS (Apple limitation). Real-time sync uses the WebSocket connection instead — it works while the app is open.
+- **Editor**: text formatting uses `document.execCommand` (deprecated). Phase 6 will migrate to ProseMirror.

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -6,11 +6,25 @@ This guide walks you through running your own Bedroc server so only you (and peo
 
 ---
 
+## How Bedroc works
+
+Bedroc has two parts:
+
+- **Frontend** — the app itself. Available publicly at `https://bedroc.cagancalidag.com`. You don't need to host this — it works from any browser or as a PWA (add to home screen).
+- **Backend** — the server that stores your encrypted notes. This is what you self-host.
+
+When you log in or register, there is a **Server** field that lets you point the app at your own backend. The default is the public hosted server. Change it to your own URL to use your self-hosted instance.
+
+This means you can use the public frontend URL and just change the server — no need to host the frontend at all.
+
+---
+
 ## What you need
 
-- A computer or VPS (Virtual Private Server) to act as the server
-  - Any Linux VPS from DigitalOcean, Hetzner, Linode, Vultr, etc. works — the cheapest tier (~$5/month) is plenty
-  - You can also self-host on a home server or a spare machine
+- A machine to run the server on:
+  - A Linux VPS from DigitalOcean, Hetzner, Linode, Vultr, etc. (~$5/month, cheapest tier is plenty)
+  - A home server, Raspberry Pi, or spare computer
+  - A Windows or macOS machine (for testing; a VPS is better for 24/7 availability)
 - **Docker** and **Docker Compose** installed on that machine
 - Basic comfort opening a terminal
 
@@ -37,7 +51,7 @@ Pick your platform below:
 ### macOS
 
 1. Go to [docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop) and download **Docker Desktop for Mac**
-   - Choose "Apple Chip" if you have an M1/M2/M3 Mac, or "Intel Chip" otherwise
+   - Choose "Apple Chip" if you have an M1/M2/M3/M4 Mac, or "Intel Chip" otherwise
 2. Open the downloaded `.dmg`, drag Docker to Applications, then launch it
 3. Wait for the whale icon in the menu bar to stop animating
 4. Open **Terminal** and run:
@@ -83,6 +97,22 @@ docker --version
 docker compose version
 ```
 
+### Linux (Fedora / RHEL / CentOS)
+
+```bash
+sudo dnf -y install dnf-plugins-core
+sudo dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+sudo dnf install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo systemctl enable --now docker
+sudo usermod -aG docker $USER
+```
+
+Log out and back in, then verify:
+```bash
+docker --version
+docker compose version
+```
+
 ---
 
 ## Part 2 — Set up WireGuard (recommended for private access)
@@ -91,20 +121,47 @@ Bedroc's default setup uses [WireGuard](https://www.wireguard.com/) — a modern
 
 If you just want to test locally or on a LAN, you can skip this and come back to it later. Jump to Part 3 — but note that without WireGuard or a domain with HTTPS, the setup will use plain HTTP.
 
-### Install WireGuard on your server (Linux)
+### Option A — Use the wg-easy web UI (easiest)
+
+[wg-easy](https://github.com/wg-easy/wg-easy) is a Docker container that gives you a web dashboard for managing WireGuard peers. It's the easiest way to get WireGuard running.
+
+```bash
+docker run -d \
+  --name=wg-easy \
+  -e LANG=en \
+  -e WG_HOST=YOUR_VPS_PUBLIC_IP \
+  -e PASSWORD_HASH='YOUR_BCRYPT_HASH' \
+  -v ~/.wg-easy:/etc/wireguard \
+  -p 51820:51820/udp \
+  -p 51821:51821/tcp \
+  --cap-add=NET_ADMIN \
+  --cap-add=SYS_MODULE \
+  --sysctl="net.ipv4.conf.all.src_valid_mark=1" \
+  --sysctl="net.ipv6.conf.all.disable_ipv6=1" \
+  --restart unless-stopped \
+  ghcr.io/wg-easy/wg-easy
+```
+
+Open `http://YOUR_VPS_IP:51821` to manage clients. Download the config file for each device and import it into the WireGuard app.
+
+Make sure UDP port 51820 is open in your firewall.
+
+### Option B — Manual WireGuard (more control)
+
+#### Install WireGuard on your server (Linux)
 
 ```bash
 sudo apt-get install -y wireguard
 ```
 
-### Generate server keys
+#### Generate server keys
 
 ```bash
 wg genkey | sudo tee /etc/wireguard/server_private.key | wg pubkey | sudo tee /etc/wireguard/server_public.key
 sudo chmod 600 /etc/wireguard/server_private.key
 ```
 
-### Create `/etc/wireguard/wg0.conf`
+#### Create `/etc/wireguard/wg0.conf`
 
 Replace `YOUR_SERVER_PRIVATE_KEY` with the contents of `/etc/wireguard/server_private.key`:
 
@@ -122,7 +179,7 @@ PostDown = iptables -D FORWARD -i wg0 -j ACCEPT; iptables -t nat -D POSTROUTING 
 
 > If your network interface is not `eth0`, replace it with the correct name (`ip link` to check).
 
-### Start WireGuard
+#### Start WireGuard
 
 ```bash
 sudo systemctl enable wg-quick@wg0
@@ -134,7 +191,7 @@ Verify it's running:
 sudo wg show
 ```
 
-### Open the WireGuard port in your firewall
+#### Open the WireGuard port in your firewall
 
 If using `ufw`:
 ```bash
@@ -143,7 +200,7 @@ sudo ufw allow 51820/udp
 
 If your VPS has a cloud firewall (DigitalOcean, Hetzner, etc.), also open UDP port 51820 in the control panel.
 
-### Adding a device (phone, laptop, etc.)
+#### Adding a device (phone, laptop, etc.)
 
 On the **server**, generate a key pair for the new device:
 
@@ -169,9 +226,11 @@ sudo wg syncconf wg0 <(sudo wg-quick strip wg0)
 ```
 
 On the **device**, install the WireGuard app:
-- iPhone/iPad: [App Store](https://apps.apple.com/app/wireguard/id1441195209)
-- Android: [Play Store](https://play.google.com/store/apps/details?id=com.wireguard.android)
+
+- iPhone/iPad: App Store → "WireGuard"
+- Android: Play Store → "WireGuard"
 - Windows/Mac: [wireguard.com/install](https://www.wireguard.com/install/)
+- Linux: `sudo apt install wireguard` or equivalent
 
 Create a tunnel with this config (replace the placeholders):
 
@@ -205,7 +264,7 @@ Or download and extract the ZIP from GitHub.
 
 ### Create the SSL certificate
 
-Even with WireGuard, the app needs HTTPS so the browser allows access to encrypted storage (IndexedDB, Service Workers, etc.). A self-signed certificate is fine — WireGuard peers trust it because they're connecting over an already-encrypted tunnel.
+Even with WireGuard, the app needs HTTPS so the browser allows access to encrypted storage and service workers (required for offline/PWA functionality). A self-signed certificate is fine — WireGuard peers trust it because they're connecting over an already-encrypted tunnel.
 
 ```bash
 mkdir -p docker/ssl
@@ -232,11 +291,12 @@ Open `.env` in a text editor and fill in:
 | `DATABASE_URL` | Replace `CHANGE_THIS_DB_PASSWORD` with the same string you put in `POSTGRES_PASSWORD` |
 | `JWT_ACCESS_SECRET` | Run `openssl rand -hex 32` and paste the output |
 | `JWT_REFRESH_SECRET` | Run `openssl rand -hex 32` **again** (must be different from above) |
-| `CORS_ORIGIN` | `https://10.66.66.1` (or your domain: `https://notes.yourdomain.com`) |
+| `CORS_ORIGIN` | Leave **empty** to accept any frontend (recommended), or set to your specific frontend URL for strict mode |
 
-Leave everything else as-is unless you know what you're changing.
+**Leave `CORS_ORIGIN` empty** if you want to use the public Bedroc frontend (`https://bedroc.cagancalidag.com`) or any other frontend with your server. Set it to a specific URL only if you want to restrict access to one frontend.
 
 **How to generate secrets:**
+
 ```bash
 openssl rand -hex 32
 ```
@@ -268,10 +328,11 @@ docker compose logs postgres
 ### If using WireGuard
 
 1. Connect your device to the WireGuard VPN
-2. Open the Bedroc app (or visit `https://10.66.66.1` in your browser)
-3. Your browser will warn about the self-signed certificate — this is expected. Click "Advanced" → "Proceed" (Chrome) or "Accept the Risk and Continue" (Firefox)
-4. On the login/register page, the "Server" field should already show `https://10.66.66.1`
-5. Register an account and start using Bedroc
+2. Open the Bedroc app (visit `https://bedroc.cagancalidag.com` or your own frontend URL)
+3. On the login/register page, tap/click **"Server: api.bedroc.app ▾"** to expand the server field
+4. Enter `https://10.66.66.1` as your server URL
+5. Your browser will warn about the self-signed certificate — this is expected. Click "Advanced" → "Proceed" (Chrome/Edge) or "Accept the Risk and Continue" (Firefox) or "Visit Website" (Safari)
+6. Register an account and start using Bedroc
 
 ### If using a public domain
 
@@ -279,27 +340,37 @@ docker compose logs postgres
 2. Generate a real SSL certificate with Certbot:
    ```bash
    sudo apt-get install -y certbot
-   sudo certbot certonly --standalone -d notes.yourdomain.com
-   sudo cp /etc/letsencrypt/live/notes.yourdomain.com/fullchain.pem docker/ssl/cert.pem
-   sudo cp /etc/letsencrypt/live/notes.yourdomain.com/privkey.pem docker/ssl/key.pem
+   sudo certbot certonly --standalone -d api.yourdomain.com
+   sudo cp /etc/letsencrypt/live/api.yourdomain.com/fullchain.pem docker/ssl/cert.pem
+   sudo cp /etc/letsencrypt/live/api.yourdomain.com/privkey.pem docker/ssl/key.pem
    ```
-3. In `.env`, change `CORS_ORIGIN=https://notes.yourdomain.com`
-4. Update `docker/nginx/nginx.conf` — change `10.66.66.1` to `0.0.0.0` in the `listen` directives, and set the `server_name` to your domain
-5. Run `docker compose up -d --build`
-6. Open `https://notes.yourdomain.com` in your browser
+3. Update `docker/nginx/nginx.conf` — change `10.66.66.1` to `0.0.0.0` in the `listen` directives, and set the `server_name` to your domain
+4. Run `docker compose up -d --build`
+5. Open `https://bedroc.cagancalidag.com`, tap **Server**, and enter `https://api.yourdomain.com`
 
-### From the Bedroc app or website
+### Entering your server URL
 
-In the Server field on the login/register page, enter your server address in any format:
+On the login/register page, tap the **"Server: ..."** line to expand it. Type your server address in any format:
 
 | What you type | What Bedroc uses |
 |---|---|
 | `10.66.66.1` | `http://10.66.66.1` |
 | `10.66.66.1:3000` | `http://10.66.66.1:3000` |
-| `notes.yourdomain.com` | `https://notes.yourdomain.com` |
-| `https://notes.yourdomain.com` | `https://notes.yourdomain.com` |
+| `api.yourdomain.com` | `https://api.yourdomain.com` |
+| `https://api.yourdomain.com` | `https://api.yourdomain.com` |
+| `100.64.1.5` (Tailscale IP) | `http://100.64.1.5` |
 
-The app saves your server URL so you only need to enter it once.
+The app saves your server URL so you only need to enter it once. Multiple saved servers are remembered.
+
+### Using Bedroc as a PWA (add to home screen)
+
+Bedroc works as an installable app on any device:
+
+- **iOS (Safari):** Open `https://bedroc.cagancalidag.com` → tap the Share button → "Add to Home Screen"
+- **Android (Chrome):** Open the site → tap the three-dot menu → "Add to Home Screen" or "Install App"
+- **Desktop (Chrome/Edge):** Click the install icon in the address bar, or menu → "Install Bedroc"
+
+Once installed, the app works offline and loads instantly from cache. Notes you've already opened are available without a network connection. New notes written offline are queued and synced automatically when you reconnect.
 
 ---
 
@@ -388,18 +459,37 @@ Add this line to back up every day at 3am:
 
 ### "Cannot reach server" in the app
 
-1. Make sure you're connected to WireGuard (if using VPN setup)
-2. Check that all Docker containers are running: `docker compose ps`
-3. Test the health endpoint from your server: `curl http://localhost:3000/health`
-4. Check the server logs: `docker compose logs server`
+1. Check that the server field shows the correct URL (tap it on the login page)
+2. Make sure you're connected to WireGuard (if using VPN setup)
+3. Check that all Docker containers are running: `docker compose ps`
+4. Test the health endpoint from your server: `curl http://localhost:3000/health`
+5. Check the server logs: `docker compose logs server`
 
 ### "Certificate error" / browser warning
 
 Expected with a self-signed certificate. Click through the warning once. The connection is still encrypted — the warning just means the certificate wasn't issued by a public certificate authority.
 
+On iOS/Safari, you may need to go to Settings → General → VPN & Device Management → trust the certificate.
+
+### App won't install as PWA on iOS
+
+The app must be served over HTTPS for PWA installation to work. If you're using a self-signed cert on WireGuard, you need to trust the certificate first (see above). Once trusted, the "Add to Home Screen" option will work.
+
+### Offline notes not syncing when back online
+
+The app syncs automatically when it detects a network connection. If sync is stuck:
+
+1. Open the app and wait a moment — sync runs on page load and when reconnecting
+2. Check Settings → the server status indicator should turn green when online
+3. If the server is unreachable, check your WireGuard connection or VPS status
+
+### Conflict resolution
+
+If you edited the same note on two devices while offline, the app will detect the conflict when syncing. A conflict notice will appear on the note, letting you choose which version to keep (or manually merge changes). Conflicts are never silently discarded.
+
 ### Forgot to save my server address
 
-The app shows a "Server" toggle on the login page. Click it to see or change the server URL.
+The server field is on the login page. Tap the "Server: ..." line to see or change it.
 
 ### Database won't start
 
@@ -430,3 +520,5 @@ Then connect to `https://10.66.66.1:8443` instead.
 - WireGuard means no attack surface on the public internet — the server is literally unreachable without a valid VPN peer key.
 - Back up your WireGuard private key (`/etc/wireguard/server_private.key`) separately from the server. If you lose it, connected devices can no longer reach the server until you regenerate and redistribute keys.
 - **Password loss = data loss.** The encryption key is derived from your password. There is no account recovery. Use a password manager.
+- **CORS:** By default, `CORS_ORIGIN` is empty — any frontend (including the public hosted one) can connect to your server. Security is enforced by JWT tokens, not CORS. Set `CORS_ORIGIN` to a specific URL to restrict to one frontend only.
+- You can change your password in Settings → Security → Change Password. This re-derives the master key and re-wraps the encryption key. To invalidate all existing sessions after a password change, also use "Revoke all sessions" in Settings.

--- a/bedroc/Dockerfile
+++ b/bedroc/Dockerfile
@@ -34,8 +34,8 @@ RUN rm /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/build /usr/share/nginx/html
 
 # Simple nginx config: serve static files, SPA fallback to index.html
-# The real reverse-proxy config lives in docker/nginx/nginx.conf
-COPY docker/nginx-static.conf /etc/nginx/conf.d/app.conf
+# nginx-static.conf lives in bedroc/ (same build context as this Dockerfile)
+COPY nginx-static.conf /etc/nginx/conf.d/app.conf
 
 EXPOSE 8080
 

--- a/bedroc/nginx-static.conf
+++ b/bedroc/nginx-static.conf
@@ -1,0 +1,23 @@
+# Internal nginx config for the bedroc frontend container.
+# This serves static files only — the outer nginx.conf handles TLS,
+# WireGuard binding, and proxy_pass to this container.
+
+server {
+    listen 8080;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Serve static assets with long cache TTL (they have content-hashed names)
+    location ~* \.(js|css|woff2?|png|ico|webmanifest|svg)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # SPA fallback: any unmatched path serves index.html
+    # SvelteKit client-side routing handles the rest
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/bedroc/src/lib/db/indexeddb.ts
+++ b/bedroc/src/lib/db/indexeddb.ts
@@ -4,13 +4,14 @@
  * Stores all user data locally so the app works fully offline.
  * The server is a sync target, not the primary store.
  *
- * Database: "bedroc" (version 1)
+ * Database: "bedroc" (version 2)
  * Object stores:
  *   notes      — NoteLocal records (decrypted title/body stored in plain text)
  *   topics     — TopicLocal records
  *   folders    — FolderLocal records
  *   syncQueue  — pending writes to be flushed to server (encrypted)
  *   keyMaterial — encrypted DEK + derivation params (one record per account)
+ *   conflicts  — ConflictRecord: both versions of a note when a sync conflict is detected
  *
  * Design decisions:
  *   - notes are stored DECRYPTED in IndexedDB (client-local only).
@@ -22,6 +23,10 @@
  *     the server plus the dekSalt needed to re-derive the master key from password.
  *     This allows the app to restore the DEK from password on next open without
  *     fetching from the server while offline.
+ *   - conflicts stores both the local and server versions of a note. The local
+ *     version is preserved until the user resolves the conflict. Resolution can
+ *     be: keep local, keep server, or write a custom merge. Resolved conflicts
+ *     are removed from this store.
  */
 
 // ---------------------------------------------------------------------------
@@ -82,13 +87,34 @@ export interface KeyMaterialRecord {
   dekSaltHex: string;     // hex 32-byte salt for PBKDF2
 }
 
+/**
+ * A conflict record created when syncFromServer() finds that the server has
+ * a newer version of a note that was also edited locally (unsynced).
+ *
+ * Both versions are stored so the user can resolve without data loss.
+ */
+export interface ConflictRecord {
+  noteId: string;           // the note's ID (also the keyPath)
+  userId: string;
+  // Local version (what the user wrote offline)
+  localTitle: string;
+  localBody: string;
+  localUpdatedAt: number;   // clientUpdatedAt from the local NoteLocal
+  // Server version (what was on the server)
+  serverTitle: string;
+  serverBody: string;
+  serverUpdatedAt: number;  // serverUpdatedAt from the incoming ServerNote
+  serverVersion: number;
+  detectedAt: number;       // when the conflict was detected
+}
+
 // ---------------------------------------------------------------------------
 // DB singleton
 // ---------------------------------------------------------------------------
 
 let db: IDBDatabase | null = null;
 const DB_NAME = 'bedroc';
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 
 /** Open (or return cached) IndexedDB instance. */
 export function openDb(): Promise<IDBDatabase> {
@@ -99,30 +125,40 @@ export function openDb(): Promise<IDBDatabase> {
 
     req.onupgradeneeded = (event) => {
       const d = (event.target as IDBOpenDBRequest).result;
+      const oldVersion = event.oldVersion;
 
-      // notes
-      const notes = d.createObjectStore('notes', { keyPath: 'id' });
-      notes.createIndex('by_user', 'userId');
-      notes.createIndex('by_user_topic', ['userId', 'topicId']);
-      notes.createIndex('by_user_order', ['userId', 'customOrder']);
-      notes.createIndex('by_updated', ['userId', 'clientUpdatedAt']);
-      notes.createIndex('unsynced', ['userId', 'synced']);
+      if (oldVersion < 1) {
+        // notes
+        const notes = d.createObjectStore('notes', { keyPath: 'id' });
+        notes.createIndex('by_user', 'userId');
+        notes.createIndex('by_user_topic', ['userId', 'topicId']);
+        notes.createIndex('by_user_order', ['userId', 'customOrder']);
+        notes.createIndex('by_updated', ['userId', 'clientUpdatedAt']);
+        notes.createIndex('unsynced', ['userId', 'synced']);
 
-      // topics
-      const topics = d.createObjectStore('topics', { keyPath: 'id' });
-      topics.createIndex('by_user', 'userId');
+        // topics
+        const topics = d.createObjectStore('topics', { keyPath: 'id' });
+        topics.createIndex('by_user', 'userId');
 
-      // folders
-      const folders = d.createObjectStore('folders', { keyPath: 'id' });
-      folders.createIndex('by_user', 'userId');
+        // folders
+        const folders = d.createObjectStore('folders', { keyPath: 'id' });
+        folders.createIndex('by_user', 'userId');
 
-      // syncQueue
-      const queue = d.createObjectStore('syncQueue', { keyPath: 'id' });
-      queue.createIndex('by_type', 'type');
-      queue.createIndex('by_created', 'createdAt');
+        // syncQueue
+        const queue = d.createObjectStore('syncQueue', { keyPath: 'id' });
+        queue.createIndex('by_type', 'type');
+        queue.createIndex('by_created', 'createdAt');
 
-      // keyMaterial
-      d.createObjectStore('keyMaterial', { keyPath: 'id' });
+        // keyMaterial
+        d.createObjectStore('keyMaterial', { keyPath: 'id' });
+      }
+
+      if (oldVersion < 2) {
+        // conflicts — stores both versions of a note when a sync conflict is detected
+        const conflicts = d.createObjectStore('conflicts', { keyPath: 'noteId' });
+        conflicts.createIndex('by_user', 'userId');
+        conflicts.createIndex('by_detected', 'detectedAt');
+      }
     };
 
     req.onsuccess = (event) => {
@@ -288,13 +324,38 @@ export async function clearKeyMaterial(): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// Conflicts
+// ---------------------------------------------------------------------------
+
+export async function saveConflict(record: ConflictRecord): Promise<void> {
+  const store = await getStore('conflicts', 'readwrite');
+  await idbRequest(store.put(record));
+}
+
+export async function getConflict(noteId: string): Promise<ConflictRecord | undefined> {
+  const store = await getStore('conflicts', 'readonly');
+  return idbRequest(store.get(noteId));
+}
+
+export async function getConflictsByUser(userId: string): Promise<ConflictRecord[]> {
+  const store = await getStore('conflicts', 'readonly');
+  const idx = store.index('by_user');
+  return idbRequest<ConflictRecord[]>(idx.getAll(userId));
+}
+
+export async function deleteConflict(noteId: string): Promise<void> {
+  const store = await getStore('conflicts', 'readwrite');
+  await idbRequest(store.delete(noteId));
+}
+
+// ---------------------------------------------------------------------------
 // Full wipe (logout / account delete)
 // ---------------------------------------------------------------------------
 
 /** Clear all data for a user from every object store. */
 export async function wipeLocalData(userId: string): Promise<void> {
   const d = await openDb();
-  const tx = d.transaction(['notes', 'topics', 'folders', 'syncQueue', 'keyMaterial'], 'readwrite');
+  const tx = d.transaction(['notes', 'topics', 'folders', 'syncQueue', 'keyMaterial', 'conflicts'], 'readwrite');
 
   // Delete notes
   const noteIdx = tx.objectStore('notes').index('by_user');
@@ -332,9 +393,10 @@ export async function wipeLocalData(userId: string): Promise<void> {
     req.onerror = () => reject(req.error);
   });
 
-  // Clear entire sync queue and key material
+  // Clear entire sync queue, key material, and conflicts
   tx.objectStore('syncQueue').clear();
   tx.objectStore('keyMaterial').clear();
+  tx.objectStore('conflicts').clear();
 
   await new Promise<void>((resolve, reject) => {
     tx.oncomplete = () => resolve();

--- a/bedroc/src/lib/stores/auth.svelte.ts
+++ b/bedroc/src/lib/stores/auth.svelte.ts
@@ -558,3 +558,93 @@ export async function unlockWithPassword(password: string): Promise<void> {
     _loading = false;
   }
 }
+
+// ---------------------------------------------------------------------------
+// Change password
+// ---------------------------------------------------------------------------
+
+/**
+ * Change the user's password.
+ *
+ * 1. Verify the current password by unwrapping the DEK with it.
+ * 2. Generate a new dekSalt and re-derive a new Master Key from the new password.
+ * 3. Re-wrap the same DEK with the new Master Key → new encryptedDek.
+ * 4. Re-compute the SRP salt + verifier from the new password.
+ * 5. POST new material to /api/auth/change-password.
+ * 6. Update IndexedDB key material for offline use.
+ *
+ * The DEK itself does not change — all notes stay encrypted and accessible.
+ *
+ * @throws if the current password is wrong or the server request fails.
+ */
+export async function changePassword(currentPassword: string, newPassword: string): Promise<void> {
+  _loading = true;
+  _error = null;
+
+  try {
+    // Step 1: Verify current password by unwrapping DEK
+    const km = await loadKeyMaterial();
+    if (!km) throw new Error('No local key material. Please log in again.');
+
+    const oldSaltBytes = fromHex(km.dekSaltHex);
+    const oldMasterKey = await deriveMasterKey(currentPassword, oldSaltBytes);
+    // This throws if the password is wrong
+    const dekRaw = await (async () => {
+      const { fromBase64 } = await import('$lib/crypto/keys.js');
+      const { iv, ct } = JSON.parse(km.encryptedDek) as { iv: string; ct: string };
+      const raw = await crypto.subtle.decrypt(
+        { name: 'AES-GCM', iv: fromBase64(iv) },
+        oldMasterKey,
+        fromBase64(ct)
+      );
+      return new Uint8Array(raw);
+    })();
+
+    if (!_username) throw new Error('Not logged in.');
+
+    // Step 2: New salt + new master key
+    const newDekSaltBytes = randomBytes(32);
+    const newDekSaltHex = toHex(newDekSaltBytes);
+    const newMasterKey = await deriveMasterKey(newPassword, newDekSaltBytes);
+
+    // Step 3: Re-wrap the same DEK bytes with new master key
+    const newEncryptedDek = await wrapDek(dekRaw, newMasterKey);
+
+    // Step 4: New SRP verifier for new password
+    const { salt: newSrpSalt, verifier: newSrpVerifier } = await srpRegister(_username, newPassword);
+
+    // Step 5: Send to server
+    const res = await apiFetch('/api/auth/change-password', {
+      method: 'POST',
+      body: JSON.stringify({
+        srpSalt:      newSrpSalt,
+        srpVerifier:  newSrpVerifier,
+        encryptedDek: newEncryptedDek,
+        dekSalt:      newDekSaltHex,
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({})) as { error?: string };
+      throw new Error(body.error ?? 'Failed to change password. Please try again.');
+    }
+
+    // Step 6: Update in-memory DEK + IndexedDB
+    const { unwrapDek: unwrap } = await import('$lib/crypto/keys.js');
+    _dek = await unwrap(newEncryptedDek, newMasterKey);
+
+    await saveKeyMaterial({
+      id: 'current',
+      username: _username,
+      serverUrl: _serverUrl,
+      encryptedDek: newEncryptedDek,
+      dekSaltHex: newDekSaltHex,
+    });
+
+  } catch (err) {
+    _error = (err as Error).message;
+    throw err;
+  } finally {
+    _loading = false;
+  }
+}

--- a/bedroc/src/lib/stores/notes.svelte.ts
+++ b/bedroc/src/lib/stores/notes.svelte.ts
@@ -28,6 +28,7 @@ import { auth, apiFetch } from './auth.svelte.js';
 import { encryptNote, decryptNote } from '$lib/crypto/encrypt.js';
 import {
   saveNote as idbSaveNote,
+  getNoteById as idbGetNoteById,
   getNotesByUser,
   getNotesByTopic as idbGetNotesByTopic,
   markNoteDeleted as idbMarkDeleted,
@@ -41,10 +42,14 @@ import {
   dequeueSyncItem,
   getAllSyncQueue,
   incrementRetry,
+  saveConflict,
+  deleteConflict,
+  getConflictsByUser,
   type NoteLocal,
   type TopicLocal,
   type FolderLocal,
   type SyncQueueItem,
+  type ConflictRecord,
 } from '$lib/db/indexeddb.js';
 
 // ---------------------------------------------------------------------------
@@ -89,6 +94,14 @@ export const foldersMap = new SvelteMap<string, Folder>();
 
 let _syncing = $state(false);
 export const syncState = { get syncing() { return _syncing; } };
+
+// ---------------------------------------------------------------------------
+// Conflicts reactive map
+// ---------------------------------------------------------------------------
+
+export const conflictsMap = new SvelteMap<string, ConflictRecord>();
+
+export { type ConflictRecord };
 
 // ---------------------------------------------------------------------------
 // Sort mode (localStorage — user pref, not encrypted)
@@ -139,15 +152,17 @@ export async function loadFromDb(): Promise<void> {
   const userId = auth.userId;
   if (!userId) return;
 
-  const [notes, topics, folders] = await Promise.all([
+  const [notes, topics, folders, conflicts] = await Promise.all([
     getNotesByUser(userId),
     getTopicsByUser(userId),
     getFoldersByUser(userId),
+    getConflictsByUser(userId),
   ]);
 
   notesMap.clear();
   topicsMap.clear();
   foldersMap.clear();
+  conflictsMap.clear();
 
   for (const n of notes) {
     notesMap.set(n.id, localToNote(n));
@@ -158,6 +173,9 @@ export async function loadFromDb(): Promise<void> {
   for (const f of folders) {
     foldersMap.set(f.id, localToFolder(f));
   }
+  for (const c of conflicts) {
+    conflictsMap.set(c.noteId, c);
+  }
 }
 
 /** Clear reactive maps on logout. */
@@ -165,6 +183,7 @@ export function clearStore(): void {
   notesMap.clear();
   topicsMap.clear();
   foldersMap.clear();
+  conflictsMap.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -186,6 +205,17 @@ function setLastSync(iso: string): void {
 /**
  * Pull changes from the server since last sync, decrypt and merge locally.
  * Safe to call at any time; skips if no DEK is available.
+ *
+ * Conflict detection:
+ *   A conflict occurs when ALL of:
+ *     1. The server has a version newer than what the local copy last saw
+ *     2. The local copy has unsynced edits (synced: false)
+ *     3. The local copy was edited after its last known server update
+ *
+ *   When detected: both versions are saved to the `conflicts` store.
+ *   The local (unsynced) note is NEVER overwritten — user must resolve.
+ *
+ *   Fast-forward (no conflict): server version is accepted and local is updated.
  */
 export async function syncFromServer(): Promise<void> {
   const dek = auth.dek;
@@ -203,8 +233,58 @@ export async function syncFromServer(): Promise<void> {
       syncedAt: string;
     };
 
-    // Decrypt and merge each note
     for (const sn of data.notes) {
+      const serverUpdatedAt = new Date(sn.server_updated_at).getTime();
+
+      // Handle server-side deletes — always accept
+      if (sn.is_deleted) {
+        await idbMarkDeleted(sn.id);
+        notesMap.delete(sn.id);
+        if (conflictsMap.has(sn.id)) {
+          conflictsMap.delete(sn.id);
+          await deleteConflict(sn.id);
+        }
+        continue;
+      }
+
+      // Load local record to check for conflicts
+      const existing = await idbGetNoteById(sn.id);
+
+      const hasLocalUnsyncedEdits =
+        existing &&
+        !existing.synced &&
+        existing.clientUpdatedAt > (existing.serverUpdatedAt || 0);
+
+      const serverIsNewer =
+        !existing ||
+        serverUpdatedAt > (existing.serverUpdatedAt || 0);
+
+      if (hasLocalUnsyncedEdits && serverIsNewer) {
+        // --- CONFLICT ---
+        const { title: serverTitle, body: serverBody } = await decryptNote(
+          sn.encrypted_title, sn.encrypted_body, dek
+        );
+
+        const conflict: ConflictRecord = {
+          noteId: sn.id,
+          userId,
+          localTitle: existing.title,
+          localBody: existing.body,
+          localUpdatedAt: existing.clientUpdatedAt,
+          serverTitle,
+          serverBody,
+          serverUpdatedAt,
+          serverVersion: sn.version,
+          detectedAt: Date.now(),
+        };
+
+        await saveConflict(conflict);
+        conflictsMap.set(sn.id, conflict);
+        // Do NOT overwrite the local note — user must resolve the conflict
+        continue;
+      }
+
+      // --- Fast-forward (no conflict) ---
       const { title, body } = await decryptNote(sn.encrypted_title, sn.encrypted_body, dek);
 
       const local: NoteLocal = {
@@ -215,18 +295,19 @@ export async function syncFromServer(): Promise<void> {
         body,
         customOrder: sn.custom_order,
         clientUpdatedAt: new Date(sn.client_updated_at).getTime(),
-        serverUpdatedAt: new Date(sn.server_updated_at).getTime(),
-        isDeleted: sn.is_deleted,
+        serverUpdatedAt,
+        isDeleted: false,
         version: sn.version,
         synced: true,
       };
 
       await idbSaveNote(local);
+      notesMap.set(sn.id, localToNote(local));
 
-      if (sn.is_deleted) {
-        notesMap.delete(sn.id);
-      } else {
-        notesMap.set(sn.id, localToNote(local));
+      // Clear any stale conflict for this note
+      if (conflictsMap.has(sn.id)) {
+        conflictsMap.delete(sn.id);
+        await deleteConflict(sn.id);
       }
     }
 
@@ -241,6 +322,66 @@ export async function syncFromServer(): Promise<void> {
   } finally {
     _syncing = false;
   }
+}
+
+/**
+ * Resolve a conflict by choosing which version to keep, or providing a merge.
+ *
+ * @param noteId     - the conflicted note's ID
+ * @param resolution - 'local' | 'server' | { title, body } for a custom merge
+ */
+export async function resolveConflict(
+  noteId: string,
+  resolution: 'local' | 'server' | { title: string; body: string }
+): Promise<void> {
+  const conflict = conflictsMap.get(noteId);
+  if (!conflict) return;
+
+  const dek = auth.dek!;
+  const userId = auth.userId!;
+
+  let title: string;
+  let body: string;
+
+  if (resolution === 'local') {
+    title = conflict.localTitle;
+    body = conflict.localBody;
+  } else if (resolution === 'server') {
+    title = conflict.serverTitle;
+    body = conflict.serverBody;
+  } else {
+    title = resolution.title;
+    body = resolution.body;
+  }
+
+  const now = Date.now();
+  const existing = await idbGetNoteById(noteId);
+
+  const local: NoteLocal = {
+    id: noteId,
+    userId,
+    topicId: existing?.topicId ?? null,
+    title,
+    body,
+    customOrder: existing?.customOrder ?? 0,
+    clientUpdatedAt: now,
+    serverUpdatedAt: conflict.serverUpdatedAt,
+    isDeleted: false,
+    version: conflict.serverVersion,
+    synced: false,
+  };
+
+  await idbSaveNote(local);
+  notesMap.set(noteId, localToNote(local));
+
+  // Remove the conflict record
+  conflictsMap.delete(noteId);
+  await deleteConflict(noteId);
+
+  // Push the resolved version to the server
+  const { encryptedTitle, encryptedBody } = await encryptNote(title, body, dek);
+  await queueNoteUpsert(noteId, userId, local.topicId, encryptedTitle, encryptedBody, local.customOrder, now);
+  await tryServerUpsertNote(noteId, userId, local.topicId, encryptedTitle, encryptedBody, local.customOrder, now);
 }
 
 async function syncTopicsFromServer(): Promise<void> {
@@ -307,11 +448,8 @@ export async function flushSyncQueue(): Promise<void> {
           if (res.ok) {
             await dequeueSyncItem(item.id);
             // Mark as synced in IndexedDB
-            const existing = notesMap.get(item.id);
-            if (existing) {
-              const n = await import('$lib/db/indexeddb.js').then(m => m.getNoteById(item.id));
-              if (n) await idbSaveNote({ ...n, synced: true });
-            }
+            const n = await idbGetNoteById(item.id);
+            if (n) await idbSaveNote({ ...n, synced: true });
           } else {
             await incrementRetry(item.id);
           }

--- a/bedroc/src/lib/sync/websocket.ts
+++ b/bedroc/src/lib/sync/websocket.ts
@@ -1,0 +1,185 @@
+/**
+ * lib/sync/websocket.ts — WebSocket client for real-time multi-device sync.
+ *
+ * Connects to the server's /ws endpoint using the current access token.
+ * The server sends push notifications when notes are created/updated/deleted
+ * on another device — this client receives them and triggers a local sync.
+ *
+ * Protocol (defined in server/src/routes/sync.ts):
+ *   Client → Server:  { type: 'ping' }
+ *   Server → Client:  { type: 'pong' }
+ *                     { type: 'note:updated', noteId: string }
+ *                     { type: 'note:deleted', noteId: string }
+ *
+ * Features:
+ *   - Auto-reconnect with exponential backoff (1s → 2s → 4s → ... → 60s max)
+ *   - Keepalive ping every 30s to prevent idle disconnects
+ *   - Stops reconnecting after logout (call disconnect())
+ *   - Safe to call connect() multiple times — closes existing socket first
+ *   - Works in all browsers (native WebSocket API, no library needed)
+ *   - Works in PWA / add-to-homescreen context on iOS/Android
+ */
+
+import { auth } from '$lib/stores/auth.svelte.js';
+import { syncFromServer } from '$lib/stores/notes.svelte.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type ServerMessage =
+  | { type: 'pong' }
+  | { type: 'note:updated'; noteId: string }
+  | { type: 'note:deleted'; noteId: string };
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+let socket: WebSocket | null = null;
+let pingInterval: ReturnType<typeof setInterval> | null = null;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let reconnectDelay = 1000;       // ms — doubles on each failure, caps at 60s
+let intentionallyClosed = false; // set true on logout to stop reconnecting
+let connecting = false;
+
+const MAX_RECONNECT_DELAY = 60_000;
+const PING_INTERVAL = 30_000;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Connect to the WebSocket server. Safe to call multiple times. */
+export function connect(): void {
+  if (connecting) return;
+
+  const token = auth.accessToken;
+  const serverUrl = auth.serverUrl;
+  if (!token || !serverUrl) return;
+
+  // Build the WebSocket URL: replace http(s) with ws(s)
+  const wsBase = serverUrl.replace(/^https/, 'wss').replace(/^http/, 'ws');
+  const wsUrl = `${wsBase}/ws?token=${encodeURIComponent(token)}`;
+
+  intentionallyClosed = false;
+  _open(wsUrl);
+}
+
+/** Disconnect and stop all reconnect attempts. Call on logout. */
+export function disconnect(): void {
+  intentionallyClosed = true;
+  _clearTimers();
+  if (socket) {
+    socket.onclose = null; // prevent reconnect handler from firing
+    socket.close(1000, 'logout');
+    socket = null;
+  }
+  connecting = false;
+  reconnectDelay = 1000;
+}
+
+// ---------------------------------------------------------------------------
+// Internal
+// ---------------------------------------------------------------------------
+
+function _open(wsUrl: string): void {
+  connecting = true;
+
+  // Close any existing socket cleanly before opening a new one
+  if (socket && socket.readyState < WebSocket.CLOSING) {
+    socket.onclose = null;
+    socket.close(1000, 'reconnect');
+  }
+
+  try {
+    socket = new WebSocket(wsUrl);
+  } catch {
+    // WebSocket constructor can throw on invalid URLs
+    connecting = false;
+    _scheduleReconnect(wsUrl);
+    return;
+  }
+
+  socket.onopen = () => {
+    connecting = false;
+    reconnectDelay = 1000; // reset backoff on successful connect
+    _startPing();
+  };
+
+  socket.onmessage = (event: MessageEvent) => {
+    let msg: ServerMessage;
+    try {
+      msg = JSON.parse(event.data as string) as ServerMessage;
+    } catch {
+      return;
+    }
+    _handleMessage(msg);
+  };
+
+  socket.onerror = () => {
+    // onerror is always followed by onclose — let onclose handle reconnect
+  };
+
+  socket.onclose = () => {
+    connecting = false;
+    _clearPing();
+    if (!intentionallyClosed) {
+      _scheduleReconnect(wsUrl);
+    }
+    socket = null;
+  };
+}
+
+function _handleMessage(msg: ServerMessage): void {
+  switch (msg.type) {
+    case 'note:updated':
+      // Another device created or updated a note — pull from server
+      // We use full syncFromServer() rather than a single-note fetch so that
+      // topic/folder changes are also picked up.
+      syncFromServer().catch(() => {});
+      break;
+
+    case 'note:deleted':
+      // Another device deleted a note — mirror locally without a full sync
+      syncFromServer().catch(() => {});
+      break;
+
+    case 'pong':
+      // Keepalive acknowledged — nothing to do
+      break;
+  }
+}
+
+function _startPing(): void {
+  _clearPing();
+  pingInterval = setInterval(() => {
+    if (socket?.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify({ type: 'ping' }));
+    }
+  }, PING_INTERVAL);
+}
+
+function _clearPing(): void {
+  if (pingInterval !== null) {
+    clearInterval(pingInterval);
+    pingInterval = null;
+  }
+}
+
+function _scheduleReconnect(wsUrl: string): void {
+  if (intentionallyClosed) return;
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    if (!intentionallyClosed) _open(wsUrl);
+  }, reconnectDelay);
+  reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY);
+}
+
+function _clearTimers(): void {
+  _clearPing();
+  if (reconnectTimer !== null) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+}

--- a/bedroc/src/routes/+layout.svelte
+++ b/bedroc/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
 	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
 	import { auth, restoreSession } from '$lib/stores/auth.svelte.js';
+	import { connect as wsConnect, disconnect as wsDisconnect } from '$lib/sync/websocket.js';
 
 	let { children } = $props();
 
@@ -16,15 +17,41 @@
 	// mobile header on that route to avoid doubling up.
 	let isNoteRoute = $derived(path.startsWith('/note'));
 
-	// ── Auth guard ────────────────────────────────────────────────
+	// ── Service worker registration ───────────────────────────────
+	// Runs once on mount. Safe on all platforms (iOS 11.3+, Android, desktop).
+	onMount(() => {
+		if ('serviceWorker' in navigator) {
+			navigator.serviceWorker.register('/sw.js').catch(() => {
+				// Registration failure is non-fatal — app still works without SW
+			});
+		}
+	});
+
+	// ── Auth guard + WebSocket ─────────────────────────────────────
 	// On mount, try to restore session from httpOnly refresh cookie.
 	// If that fails (or DEK is missing), redirect to /login.
-	// isAuthRoute pages (login/register) skip the guard.
+	// On success, open the WebSocket connection for real-time sync.
 	onMount(async () => {
 		if (isAuthRoute) return;
 		await restoreSession();
 		if (!auth.isLoggedIn) {
 			goto('/login');
+		} else {
+			wsConnect();
+		}
+
+		// Disconnect WebSocket on page unload (tab close, navigate away)
+		return () => {
+			wsDisconnect();
+		};
+	});
+
+	// Reconnect when auth state changes (e.g. token refreshed, login from another tab)
+	$effect(() => {
+		if (auth.isLoggedIn && !isAuthRoute) {
+			wsConnect();
+		} else {
+			wsDisconnect();
 		}
 	});
 

--- a/bedroc/src/routes/note/[id]/+page.svelte
+++ b/bedroc/src/routes/note/[id]/+page.svelte
@@ -2,19 +2,53 @@
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import {
-		notesMap, topicsMap, foldersMap,
+		notesMap, topicsMap, foldersMap, conflictsMap,
 		getNotes, getTopics, getFolders,
 		createNote, createTopic, saveTopic, deleteTopic,
 		createFolder, saveFolder, toggleFolderCollapsed, deleteFolder,
 		moveTopic,
-		saveNote,
+		saveNote, resolveConflict,
 		relativeTime,
-		type Topic, type Folder
+		type Topic, type Folder, type ConflictRecord
 	} from '$lib/stores/notes.svelte';
 
 	// ── Note identity ─────────────────────────────────────────────
 	let noteId  = $derived(page.params.id);
 	let isNew   = $derived(noteId === 'new');
+
+	// ── Conflict resolution ───────────────────────────────────────
+	let conflict = $derived(noteId && !isNew ? conflictsMap.get(noteId) : undefined);
+	let showConflict = $derived(!!conflict);
+	// 'banner' = collapsed notice, 'diff' = full diff view
+	let conflictView = $state<'banner' | 'diff'>('banner');
+	// Custom merge text (used in diff view when user edits the merge area)
+	let mergeTitle = $state('');
+	let mergeBody = $state('');
+	let mergeDirty = $state(false);
+	let conflictResolving = $state(false);
+
+	$effect(() => {
+		if (conflict) {
+			mergeTitle = conflict.localTitle;
+			mergeBody = conflict.localBody;
+			mergeDirty = false;
+		}
+	});
+
+	async function handleResolveConflict(choice: 'local' | 'server' | 'merge') {
+		if (!noteId || !conflict) return;
+		conflictResolving = true;
+		try {
+			if (choice === 'merge') {
+				await resolveConflict(noteId, { title: mergeTitle, body: mergeBody });
+			} else {
+				await resolveConflict(noteId, choice);
+			}
+			conflictView = 'banner';
+		} finally {
+			conflictResolving = false;
+		}
+	}
 
 	// ── Load note ─────────────────────────────────────────────────
 	// Notes are stored decrypted in IndexedDB; encryption happens at sync time.
@@ -329,6 +363,122 @@
 		spellcheck="true"
 		autocapitalize="sentences"
 	/>
+
+	<!-- ── Conflict notice ──────────────────────────────────────── -->
+	{#if showConflict && conflict}
+		{#if conflictView === 'banner'}
+			<div class="conflict-banner" role="alert">
+				<div class="conflict-banner-icon" aria-hidden="true">
+					<svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+						<path d="M7 1L13 12H1L7 1Z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/>
+						<path d="M7 5v3.5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+						<circle cx="7" cy="10.5" r="0.6" fill="currentColor"/>
+					</svg>
+				</div>
+				<div class="conflict-banner-text">
+					<span class="conflict-banner-title">Sync conflict</span>
+					<span class="conflict-banner-desc">
+						This note was edited on another device while you were offline.
+					</span>
+				</div>
+				<div class="conflict-banner-actions">
+					<button class="conflict-btn-resolve" onclick={() => (conflictView = 'diff')}>
+						Resolve
+					</button>
+					<button class="conflict-btn-dismiss" onclick={() => handleResolveConflict('local')} title="Keep your version and discard server version">
+						Keep mine
+					</button>
+				</div>
+			</div>
+		{:else}
+			<!-- Full diff view -->
+			<div class="conflict-diff">
+				<div class="conflict-diff-header">
+					<svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+						<path d="M7 1L13 12H1L7 1Z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/>
+						<path d="M7 5v3.5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+						<circle cx="7" cy="10.5" r="0.6" fill="currentColor"/>
+					</svg>
+					<span>Resolve sync conflict</span>
+					<button class="conflict-diff-close" onclick={() => (conflictView = 'banner')} aria-label="Collapse conflict view">
+						<svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+							<path d="M2 2l8 8M10 2l-8 8" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+						</svg>
+					</button>
+				</div>
+
+				<div class="conflict-versions">
+					<!-- Your version -->
+					<div class="conflict-version conflict-version-local">
+						<div class="conflict-version-label">
+							Your version
+							<span class="conflict-version-time">
+								{relativeTime(conflict.localUpdatedAt)}
+							</span>
+						</div>
+						<div class="conflict-version-title">{conflict.localTitle || '(no title)'}</div>
+						<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+						<div class="conflict-version-body">{@html conflict.localBody || '<em>(empty)</em>'}</div>
+						<button
+							class="conflict-pick-btn"
+							onclick={() => handleResolveConflict('local')}
+							disabled={conflictResolving}
+						>
+							Use this version
+						</button>
+					</div>
+
+					<!-- Server version -->
+					<div class="conflict-version conflict-version-server">
+						<div class="conflict-version-label">
+							Server version
+							<span class="conflict-version-time">
+								{relativeTime(conflict.serverUpdatedAt)}
+							</span>
+						</div>
+						<div class="conflict-version-title">{conflict.serverTitle || '(no title)'}</div>
+						<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+						<div class="conflict-version-body">{@html conflict.serverBody || '<em>(empty)</em>'}</div>
+						<button
+							class="conflict-pick-btn"
+							onclick={() => handleResolveConflict('server')}
+							disabled={conflictResolving}
+						>
+							Use this version
+						</button>
+					</div>
+				</div>
+
+				<!-- Manual merge -->
+				<div class="conflict-merge">
+					<div class="conflict-merge-label">Or write a custom merge:</div>
+					<input
+						class="conflict-merge-title"
+						type="text"
+						placeholder="Title"
+						bind:value={mergeTitle}
+						oninput={() => (mergeDirty = true)}
+					/>
+					<div
+						class="conflict-merge-body"
+						contenteditable="true"
+						role="textbox"
+						aria-label="Merge body"
+						aria-multiline="true"
+						data-placeholder="Merge content…"
+						oninput={(e) => { mergeBody = (e.currentTarget as HTMLElement).innerHTML; mergeDirty = true; }}
+					></div>
+					<button
+						class="conflict-pick-btn conflict-pick-btn-merge"
+						onclick={() => handleResolveConflict('merge')}
+						disabled={conflictResolving || !mergeDirty}
+					>
+						{conflictResolving ? 'Saving…' : 'Save merged version'}
+					</button>
+				</div>
+			</div>
+		{/if}
+	{/if}
 
 	<!-- ── Formatting toolbar ──────────────────────────────────── -->
 	<div class="format-bar" role="toolbar" aria-label="Text formatting">
@@ -748,6 +898,272 @@
 
 	.title-input:focus { border: none; box-shadow: none; }
 	.title-input::placeholder { color: var(--text-faint); font-weight: 400; }
+
+	/* ── Conflict banner ──────────────────────────────────────── */
+	.conflict-banner {
+		display: flex;
+		align-items: flex-start;
+		gap: 10px;
+		margin: 0 20px 12px;
+		padding: 10px 14px;
+		background: color-mix(in srgb, #e09a3c 12%, transparent);
+		border: 1px solid color-mix(in srgb, #e09a3c 40%, transparent);
+		border-radius: var(--radius-sm);
+		font-size: 13px;
+	}
+
+	.conflict-banner-icon {
+		color: #e09a3c;
+		flex-shrink: 0;
+		margin-top: 2px;
+	}
+
+	.conflict-banner-text {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.conflict-banner-title {
+		font-weight: 600;
+		color: #e09a3c;
+		font-size: 12.5px;
+	}
+
+	.conflict-banner-desc {
+		color: var(--text-muted);
+		font-size: 12px;
+		line-height: 1.4;
+	}
+
+	.conflict-banner-actions {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		flex-shrink: 0;
+	}
+
+	.conflict-btn-resolve {
+		padding: 4px 10px;
+		font-size: 12px;
+		font-weight: 600;
+		background: #e09a3c;
+		color: #0f1117;
+		border: none;
+		border-radius: var(--radius-sm);
+		cursor: pointer;
+		transition: opacity 0.12s ease;
+	}
+
+	.conflict-btn-resolve:hover { opacity: 0.85; }
+
+	.conflict-btn-dismiss {
+		padding: 4px 10px;
+		font-size: 12px;
+		font-weight: 500;
+		background: transparent;
+		color: var(--text-muted);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-sm);
+		cursor: pointer;
+		transition: color 0.12s ease, border-color 0.12s ease;
+	}
+
+	.conflict-btn-dismiss:hover {
+		color: var(--text);
+		border-color: var(--text-muted);
+	}
+
+	/* ── Conflict diff view ───────────────────────────────────── */
+	.conflict-diff {
+		margin: 0 20px 16px;
+		border: 1px solid color-mix(in srgb, #e09a3c 40%, transparent);
+		border-radius: var(--radius-sm);
+		overflow: hidden;
+		font-size: 13px;
+	}
+
+	.conflict-diff-header {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 8px 14px;
+		background: color-mix(in srgb, #e09a3c 12%, transparent);
+		border-bottom: 1px solid color-mix(in srgb, #e09a3c 30%, transparent);
+		color: #e09a3c;
+		font-weight: 600;
+		font-size: 12.5px;
+	}
+
+	.conflict-diff-close {
+		margin-left: auto;
+		background: transparent;
+		border: none;
+		color: var(--text-muted);
+		cursor: pointer;
+		padding: 2px;
+		display: flex;
+		align-items: center;
+	}
+
+	.conflict-diff-close:hover { color: var(--text); }
+
+	.conflict-versions {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		border-bottom: 1px solid var(--border);
+	}
+
+	@media (max-width: 600px) {
+		.conflict-versions { grid-template-columns: 1fr; }
+	}
+
+	.conflict-version {
+		padding: 12px 14px;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.conflict-version-local {
+		border-right: 1px solid var(--border);
+	}
+
+	@media (max-width: 600px) {
+		.conflict-version-local {
+			border-right: none;
+			border-bottom: 1px solid var(--border);
+		}
+	}
+
+	.conflict-version-label {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		font-size: 11px;
+		font-weight: 600;
+		letter-spacing: 0.05em;
+		text-transform: uppercase;
+		color: var(--text-muted);
+	}
+
+	.conflict-version-time {
+		font-weight: 400;
+		text-transform: none;
+		letter-spacing: 0;
+		color: var(--text-faint);
+	}
+
+	.conflict-version-title {
+		font-weight: 600;
+		font-size: 14px;
+		color: var(--text);
+	}
+
+	.conflict-version-body {
+		font-size: 12.5px;
+		color: var(--text-muted);
+		line-height: 1.5;
+		max-height: 120px;
+		overflow-y: auto;
+		white-space: pre-wrap;
+		word-break: break-word;
+	}
+
+	.conflict-pick-btn {
+		margin-top: auto;
+		padding: 5px 12px;
+		font-size: 12px;
+		font-weight: 600;
+		background: var(--bg-hover);
+		color: var(--text);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-sm);
+		cursor: pointer;
+		transition: background 0.12s ease, border-color 0.12s ease;
+		align-self: flex-start;
+	}
+
+	.conflict-pick-btn:hover:not(:disabled) {
+		background: var(--accent);
+		color: #fff;
+		border-color: var(--accent);
+	}
+
+	.conflict-pick-btn:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.conflict-merge {
+		padding: 12px 14px;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		background: var(--bg);
+	}
+
+	.conflict-merge-label {
+		font-size: 11px;
+		font-weight: 600;
+		letter-spacing: 0.05em;
+		text-transform: uppercase;
+		color: var(--text-muted);
+	}
+
+	.conflict-merge-title {
+		border: 1px solid var(--border);
+		background: var(--bg-elevated);
+		color: var(--text);
+		padding: 6px 10px;
+		border-radius: var(--radius-sm);
+		font-size: 13px;
+		font-family: inherit;
+		outline: none;
+	}
+
+	.conflict-merge-title:focus {
+		border-color: var(--accent);
+		box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 20%, transparent);
+	}
+
+	.conflict-merge-body {
+		min-height: 80px;
+		max-height: 200px;
+		overflow-y: auto;
+		border: 1px solid var(--border);
+		background: var(--bg-elevated);
+		color: var(--text);
+		padding: 8px 10px;
+		border-radius: var(--radius-sm);
+		font-size: 13px;
+		line-height: 1.5;
+		outline: none;
+	}
+
+	.conflict-merge-body:focus {
+		border-color: var(--accent);
+		box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 20%, transparent);
+	}
+
+	.conflict-merge-body:empty::before {
+		content: attr(data-placeholder);
+		color: var(--text-faint);
+		pointer-events: none;
+	}
+
+	.conflict-pick-btn-merge {
+		background: color-mix(in srgb, var(--accent) 20%, transparent);
+		border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+		color: var(--accent);
+	}
+
+	.conflict-pick-btn-merge:hover:not(:disabled) {
+		background: var(--accent);
+		color: #fff;
+		border-color: var(--accent);
+	}
 
 	/* ── Formatting toolbar ───────────────────────────────────── */
 	.format-bar {

--- a/bedroc/src/routes/settings/+page.svelte
+++ b/bedroc/src/routes/settings/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
-	import { autosave } from '$lib/stores/notes.svelte';
-	import { auth, logout, apiFetch } from '$lib/stores/auth.svelte.js';
+	import { autosave, notesMap, topicsMap } from '$lib/stores/notes.svelte';
+	import { auth, logout, apiFetch, changePassword } from '$lib/stores/auth.svelte.js';
 	import { clearStore } from '$lib/stores/notes.svelte.js';
 
 	let confirmLogout = $state(false);
@@ -21,12 +21,14 @@
 	async function loadSessions() {
 		try {
 			const res = await apiFetch('/api/auth/sessions');
-			if (res.ok) sessions = await res.json() as Session[];
-		} catch { /* offline — no sessions list */ }
+			if (res.ok) {
+				const data = await res.json() as { sessions: Session[] };
+				sessions = data.sessions ?? [];
+			}
+		} catch { /* offline */ }
 		sessionsLoading = false;
 	}
 
-	// Load on mount
 	$effect(() => { loadSessions(); });
 
 	async function revokeSession(id: string) {
@@ -52,9 +54,7 @@
 	}
 
 	// ── Autosave settings ─────────────────────────────────────────
-	// autosave.interval === 0 means disabled.
 	let autosaveEnabled = $state(autosave.interval > 0);
-	// Display value in seconds for the UI input.
 	let autosaveSeconds = $state(autosave.interval > 0 ? autosave.interval / 1000 : 1);
 
 	function handleAutosaveToggle() {
@@ -65,6 +65,87 @@
 	function handleAutosaveSecondsChange() {
 		autosaveSeconds = Math.max(0.5, autosaveSeconds);
 		if (autosaveEnabled) autosave.set(Math.round(autosaveSeconds * 1000));
+	}
+
+	// ── Change password ────────────────────────────────────────────
+	let showChangePw = $state(false);
+	let cpCurrent = $state('');
+	let cpNew = $state('');
+	let cpConfirm = $state('');
+	let cpError = $state<string | null>(null);
+	let cpSuccess = $state(false);
+	let cpLoading = $state(false);
+
+	async function handleChangePassword() {
+		cpError = null;
+		cpSuccess = false;
+		if (!cpCurrent) { cpError = 'Enter your current password.'; return; }
+		if (cpNew.length < 8) { cpError = 'New password must be at least 8 characters.'; return; }
+		if (cpNew !== cpConfirm) { cpError = 'New passwords do not match.'; return; }
+		if (cpNew === cpCurrent) { cpError = 'New password must be different from current.'; return; }
+		cpLoading = true;
+		try {
+			await changePassword(cpCurrent, cpNew);
+			cpSuccess = true;
+			cpCurrent = ''; cpNew = ''; cpConfirm = '';
+			setTimeout(() => { showChangePw = false; cpSuccess = false; }, 1800);
+		} catch (err) {
+			cpError = (err as Error).message;
+		} finally {
+			cpLoading = false;
+		}
+	}
+
+	// ── Export notes ───────────────────────────────────────────────
+	let exportLoading = $state(false);
+	let exportError = $state<string | null>(null);
+
+	async function handleExport() {
+		if (!auth.dek) { exportError = 'Vault is locked. Please log in again.'; return; }
+		exportLoading = true;
+		exportError = null;
+		try {
+			const notes = [...notesMap.values()];
+			const items = notes.map((note) => {
+				const topic = note.topicId ? topicsMap.get(note.topicId) : null;
+				return {
+					id: note.id,
+					title: note.title || 'Untitled',
+					body: note.body.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim(),
+					bodyHtml: note.body,
+					topic: topic ? { id: topic.id, name: topic.name, color: topic.color } : null,
+					createdAt: new Date(note.createdAt).toISOString(),
+					updatedAt: new Date(note.updatedAt).toISOString(),
+				};
+			});
+
+			// Group by topic name
+			const byTopic: Record<string, typeof items> = {};
+			for (const n of items) {
+				const key = n.topic?.name ?? 'Uncategorised';
+				if (!byTopic[key]) byTopic[key] = [];
+				byTopic[key].push(n);
+			}
+
+			const payload = {
+				exportedAt: new Date().toISOString(),
+				username: auth.username,
+				noteCount: items.length,
+				notes: byTopic,
+			};
+
+			const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement('a');
+			a.href = url;
+			a.download = `bedroc-export-${new Date().toISOString().slice(0, 10)}.json`;
+			a.click();
+			URL.revokeObjectURL(url);
+		} catch (err) {
+			exportError = (err as Error).message;
+		} finally {
+			exportLoading = false;
+		}
 	}
 </script>
 
@@ -144,23 +225,64 @@
 	<section class="section">
 		<h3 class="section-title">Security</h3>
 		<div class="card">
-			<button class="row row-btn">
+			<button class="row row-btn" onclick={() => { showChangePw = !showChangePw; cpError = null; cpSuccess = false; }}>
 				<div class="row-info">
 					<span class="row-label">Change password</span>
 					<span class="row-sub">Re-encrypts your data with the new password</span>
 				</div>
-				<svg width="14" height="14" viewBox="0 0 14 14" fill="none" class="chevron-right">
+				<svg width="14" height="14" viewBox="0 0 14 14" fill="none" class="chevron-right" class:rotated={showChangePw}>
 					<path d="M5 3l4 4-4 4" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
 				</svg>
 			</button>
+			{#if showChangePw}
+				<div class="divider-inner"></div>
+				<div class="change-pw-form">
+					{#if cpSuccess}
+						<p class="cp-success">Password changed successfully.</p>
+					{:else}
+						{#if cpError}
+							<p class="cp-error">{cpError}</p>
+						{/if}
+						<input
+							type="password"
+							placeholder="Current password"
+							bind:value={cpCurrent}
+							autocomplete="current-password"
+							disabled={cpLoading}
+						/>
+						<input
+							type="password"
+							placeholder="New password"
+							bind:value={cpNew}
+							autocomplete="new-password"
+							disabled={cpLoading}
+						/>
+						<input
+							type="password"
+							placeholder="Confirm new password"
+							bind:value={cpConfirm}
+							autocomplete="new-password"
+							disabled={cpLoading}
+						/>
+						<div class="cp-actions">
+							<button class="btn-ghost" onclick={() => { showChangePw = false; cpError = null; }} disabled={cpLoading}>Cancel</button>
+							<button class="btn-primary cp-save" onclick={handleChangePassword} disabled={cpLoading}>
+								{cpLoading ? 'Saving…' : 'Save'}
+							</button>
+						</div>
+					{/if}
+				</div>
+			{/if}
 			<div class="divider-inner"></div>
-			<button class="row row-btn">
+			<button class="row row-btn" onclick={handleExport} disabled={exportLoading}>
 				<div class="row-info">
 					<span class="row-label">Export notes</span>
-					<span class="row-sub">Download all notes as decrypted JSON</span>
+					<span class="row-sub">{exportLoading ? 'Preparing export…' : 'Download all notes as decrypted JSON'}</span>
+					{#if exportError}<span class="cp-error">{exportError}</span>{/if}
 				</div>
 				<svg width="14" height="14" viewBox="0 0 14 14" fill="none" class="chevron-right">
-					<path d="M5 3l4 4-4 4" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+					<path d="M7 1v8M4 6l3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+					<path d="M2 11h10" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
 				</svg>
 			</button>
 		</div>
@@ -481,5 +603,48 @@
 		color: var(--text-faint);
 		text-align: center;
 		padding-top: 8px;
+	}
+
+	/* Change password form */
+	.change-pw-form {
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+		padding: 14px;
+	}
+
+	.change-pw-form input {
+		width: 100%;
+	}
+
+	.cp-actions {
+		display: flex;
+		gap: 8px;
+		justify-content: flex-end;
+	}
+
+	.cp-save {
+		width: auto;
+		padding: 8px 16px;
+	}
+
+	.cp-error {
+		font-size: 12px;
+		color: var(--danger);
+	}
+
+	.cp-success {
+		font-size: 13px;
+		color: var(--success);
+		text-align: center;
+		padding: 4px 0;
+	}
+
+	.chevron-right {
+		transition: transform 0.15s ease;
+	}
+
+	.chevron-right.rotated {
+		transform: rotate(90deg);
 	}
 </style>

--- a/bedroc/static/sw.js
+++ b/bedroc/static/sw.js
@@ -1,0 +1,171 @@
+/**
+ * sw.js — Bedroc Service Worker
+ *
+ * Strategy:
+ *   - Static assets (JS, CSS, fonts, icons): Cache-first, update in background
+ *   - HTML navigation (SPA shell): Network-first, fall back to cached shell
+ *   - API requests (/api/*, /ws): Never cached — always network
+ *
+ * On install: pre-cache the app shell (index.html + linked assets)
+ * On activate: delete old caches
+ * On fetch: route requests per strategy above
+ *
+ * Cross-platform compatibility:
+ *   - iOS Safari 11.3+ (service workers supported since iOS 11.3)
+ *   - Android Chrome/Firefox/Samsung Browser: full support
+ *   - Desktop Chrome/Firefox/Edge/Safari: full support
+ *   - PWA add-to-homescreen on all platforms: works correctly
+ *
+ * Notes:
+ *   - iOS does NOT support push notifications from service workers (by design).
+ *     Real-time sync is handled by the WebSocket client (websocket.ts) instead.
+ *   - IndexedDB is NOT touched here — the main thread owns the data layer.
+ *     The service worker only caches the app shell (static files).
+ *   - Background Sync API is not used (poor Safari support) — sync is triggered
+ *     by the online event in the main thread instead.
+ */
+
+const CACHE_NAME = 'bedroc-v1';
+const SHELL_CACHE = 'bedroc-shell-v1';
+
+// Files to pre-cache on install. SvelteKit hashes JS/CSS filenames so we
+// can't hardcode them — instead we cache the shell on first navigation fetch.
+const PRECACHE_URLS = [
+  '/',
+  '/manifest.webmanifest',
+];
+
+// ---------------------------------------------------------------------------
+// Install — pre-cache shell
+// ---------------------------------------------------------------------------
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(SHELL_CACHE).then((cache) =>
+      cache.addAll(PRECACHE_URLS)
+    ).then(() => self.skipWaiting())
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Activate — clean up old caches
+// ---------------------------------------------------------------------------
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((key) => key !== CACHE_NAME && key !== SHELL_CACHE)
+          .map((key) => caches.delete(key))
+      )
+    ).then(() => self.clients.claim())
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Fetch — routing strategy
+// ---------------------------------------------------------------------------
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // Only handle same-origin requests
+  if (url.origin !== self.location.origin) return;
+
+  // Never intercept API or WebSocket upgrade requests
+  if (url.pathname.startsWith('/api/') || url.pathname === '/ws') return;
+
+  // Never intercept non-GET requests
+  if (request.method !== 'GET') return;
+
+  // HTML navigation — network-first, fall back to shell
+  if (request.mode === 'navigate' || request.headers.get('Accept')?.includes('text/html')) {
+    event.respondWith(networkFirstWithShellFallback(request));
+    return;
+  }
+
+  // Static assets (JS, CSS, images, fonts) — cache-first
+  if (
+    url.pathname.match(/\.(js|css|png|jpg|jpeg|svg|ico|woff2?|ttf|webmanifest)$/)
+  ) {
+    event.respondWith(cacheFirst(request));
+    return;
+  }
+
+  // Everything else — network with cache fallback
+  event.respondWith(networkWithCacheFallback(request));
+});
+
+// ---------------------------------------------------------------------------
+// Strategies
+// ---------------------------------------------------------------------------
+
+/**
+ * Network-first. On failure, return the cached SPA shell (index.html).
+ * This ensures the app loads offline even if the exact URL isn't cached.
+ */
+async function networkFirstWithShellFallback(request) {
+  try {
+    const response = await fetch(request);
+    // Cache the successful response for future offline use
+    if (response.ok) {
+      const cache = await caches.open(SHELL_CACHE);
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch {
+    // Network failed — return cached shell or root page
+    const cached = await caches.match(request);
+    if (cached) return cached;
+    // Fall back to the root shell (SPA will handle routing client-side)
+    const shell = await caches.match('/');
+    if (shell) return shell;
+    // Last resort — return a minimal offline page
+    return new Response(
+      '<!DOCTYPE html><html><head><meta charset="utf-8"><title>Bedroc — Offline</title></head>' +
+      '<body style="font-family:system-ui;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#0f1117;color:#8b8fa8">' +
+      '<div style="text-align:center"><p style="font-size:18px;color:#e2e4ed">Bedroc</p>' +
+      '<p>You\'re offline. Open the app while connected to load it into cache.</p></div></body></html>',
+      { headers: { 'Content-Type': 'text/html; charset=utf-8' } }
+    );
+  }
+}
+
+/**
+ * Cache-first. Serve from cache if available, otherwise fetch and cache.
+ */
+async function cacheFirst(request) {
+  const cached = await caches.match(request);
+  if (cached) return cached;
+
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      const cache = await caches.open(CACHE_NAME);
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch {
+    return new Response('', { status: 503, statusText: 'Service Unavailable' });
+  }
+}
+
+/**
+ * Network with cache fallback. Try network; on failure serve cached version.
+ */
+async function networkWithCacheFallback(request) {
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      const cache = await caches.open(CACHE_NAME);
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch {
+    const cached = await caches.match(request);
+    if (cached) return cached;
+    return new Response('', { status: 503, statusText: 'Service Unavailable' });
+  }
+}

--- a/bedroc/vercel.json
+++ b/bedroc/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}

--- a/docs/PLACEHOLDERS.md
+++ b/docs/PLACEHOLDERS.md
@@ -17,7 +17,7 @@ All Phase 1 placeholders have been replaced. See `lib/crypto/`, `lib/stores/auth
 | `lib/crypto/keys.ts` | ✅ Done | PBKDF2 (600k iterations) master key + AES-256-GCM DEK wrap/unwrap |
 | `lib/crypto/srp.ts` | ✅ Done | SRP-6a client (3072-bit MODP, pure BigInt, no external libraries) |
 | `lib/crypto/encrypt.ts` | ✅ Done | AES-256-GCM per-field encryption for note title + body |
-| `lib/db/indexeddb.ts` | ✅ Done | Full offline-first IndexedDB layer with sync queue |
+| `lib/db/indexeddb.ts` | ✅ Done | Full offline-first IndexedDB layer with sync queue + conflicts store (v2) |
 
 ---
 
@@ -36,35 +36,40 @@ All Phase 1 placeholders have been replaced. See `lib/crypto/`, `lib/stores/auth
 
 ---
 
-## Phase 3 — Real-time Sync
+## Phase 3 — Real-time Sync ✅ COMPLETE
 
-| File | What is placeholder | Replace with |
+| File | Status | Implementation |
 | --- | --- | --- |
-| `lib/stores/notes.svelte.ts` | No WebSocket integration | Connect to `lib/sync/websocket.ts` on login |
-| `routes/+layout.svelte` | Split-window secondary pane is an `<iframe>` sharing in-memory stores via same-origin | With IndexedDB as the source of truth, the iframe naturally shares the same DB; no extra wiring needed |
+| `lib/stores/notes.svelte.ts` | ✅ Done | WebSocket integration via `lib/sync/websocket.ts`; connect/disconnect wired in `+layout.svelte` |
+| `lib/sync/websocket.ts` | ✅ Done | WebSocket client with auto-reconnect, exponential backoff, 30s keepalive ping |
+| `routes/+layout.svelte` | ✅ Done | `wsConnect()` called after login; `wsDisconnect()` on logout; `$effect` reconnects on auth state change |
+| `lib/stores/notes.svelte.ts` | ✅ Done | Conflict detection in `syncFromServer()` — preserves local edits, stores both versions, never silently overwrites |
+| `lib/stores/notes.svelte.ts` | ✅ Done | `resolveConflict()` — user resolves with local/server/custom merge; pushes resolved version to server |
+| `routes/note/[id]/+page.svelte` | ✅ Done | Conflict resolution UI — banner + full diff view showing both versions side-by-side |
 
 ---
 
-## Phase 4 — Offline / Service Worker
+## Phase 4 — Offline / Service Worker ✅ COMPLETE
 
-| File | What is placeholder | Replace with |
+| File | Status | Implementation |
 | --- | --- | --- |
-| (none yet) | No service worker | `static/sw.js` — cache shell + static assets; serve IndexedDB data when offline |
+| `static/sw.js` | ✅ Done | Service worker: cache-first for static assets, network-first with shell fallback for navigation, never caches API/WS |
+| `routes/+layout.svelte` | ✅ Done | `navigator.serviceWorker.register('/sw.js')` on mount; works on iOS 11.3+, Android, all desktop browsers |
 
 ---
 
-## Phase 5 — Settings / Security
+## Phase 5 — Settings / Security ✅ COMPLETE
 
-| File | What is placeholder | Replace with |
+| File | Status | Implementation |
 | --- | --- | --- |
-| `routes/settings/+page.svelte` | Username shown as static string "username" | Read from auth store |
-| `routes/settings/+page.svelte` | Sessions list is hardcoded demo array | Fetch from `GET /api/auth/sessions` |
-| `routes/settings/+page.svelte` | Revoke button is a no-op | `DELETE /api/auth/sessions/:id` |
-| `routes/settings/+page.svelte` | Log out button is a no-op | Clear DEK from memory, clear IndexedDB, revoke token |
-| `routes/settings/+page.svelte` | Delete account button is a no-op | `DELETE /api/auth/account` + clear all local data |
-| `routes/settings/+page.svelte` | Change password button is a no-op | Re-derive Master Key, re-encrypt DEK, update server |
-| `routes/settings/+page.svelte` | Export notes button is a no-op | Decrypt all notes → JSON download with warning modal |
-| `lib/stores/notes.svelte.ts` | `autosave.interval` persisted to `localStorage` only | Server-backed user preferences |
+| `routes/settings/+page.svelte` | ✅ Done | Username shown from `auth.username` |
+| `routes/settings/+page.svelte` | ✅ Done | Sessions list fetched from `GET /api/auth/sessions` |
+| `routes/settings/+page.svelte` | ✅ Done | Revoke individual session — `DELETE /api/auth/sessions/:id` |
+| `routes/settings/+page.svelte` | ✅ Done | Log out — clears DEK from memory, wipes IndexedDB, revokes token |
+| `routes/settings/+page.svelte` | ✅ Done | Delete account — `DELETE /api/auth/account` + clear all local data |
+| `routes/settings/+page.svelte` | ✅ Done | Change password — re-derives master key, re-encrypts DEK, new SRP verifier |
+| `routes/settings/+page.svelte` | ✅ Done | Export notes — decrypts all notes, downloads as categorised JSON |
+| `lib/stores/notes.svelte.ts` | Deferred | `autosave.interval` persisted to `localStorage` only — server-backed user preferences deferred to Phase 5b |
 
 ---
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -20,10 +20,12 @@ WORKDIR /app
 
 # Copy dependency manifests first for better layer caching.
 # Rebuilds node_modules only when package.json changes.
-COPY package.json package-lock.json ./
+# package-lock.json is optional — copy it if present, fall back to npm install.
+COPY package.json ./
+COPY package-lock.jso[n] ./
 
 # Install ALL deps (including devDeps like typescript, tsx) for the build
-RUN npm ci
+RUN npm install --prefer-offline 2>/dev/null || npm install
 
 # Copy source
 COPY tsconfig.json ./
@@ -38,8 +40,9 @@ FROM node:22-alpine AS runner
 WORKDIR /app
 
 # Only production deps in the final image
-COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
+COPY package.json ./
+COPY package-lock.jso[n] ./
+RUN npm install --omit=dev --prefer-offline 2>/dev/null || npm install --omit=dev
 
 # Copy compiled output from builder stage
 COPY --from=builder /app/dist ./dist

--- a/server/package.json
+++ b/server/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@types/node": "^20.14.2",
     "@types/pg": "^8.11.6",
+    "@types/ws": "^8.5.10",
     "pino-pretty": "^11.0.0",
     "tsx": "^4.15.6",
     "typescript": "^5.4.5"

--- a/server/src/db/queries/users.ts
+++ b/server/src/db/queries/users.ts
@@ -71,6 +71,21 @@ export async function deleteUser(id: string): Promise<void> {
   await query('DELETE FROM users WHERE id = $1', [id]);
 }
 
+export async function updateUserCredentials(params: {
+  id: string;
+  srpSalt: Buffer;
+  srpVerifier: Buffer;
+  encryptedDek: string;
+  dekSalt: Buffer;
+}): Promise<void> {
+  await query(
+    `UPDATE users
+     SET srp_salt = $2, srp_verifier = $3, encrypted_dek = $4, dek_salt = $5
+     WHERE id = $1`,
+    [params.id, params.srpSalt, params.srpVerifier, params.encryptedDek, params.dekSalt]
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Sessions
 // ---------------------------------------------------------------------------

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -96,10 +96,27 @@ await app.register(fastifyHelmet, {
 // ---------------------------------------------------------------------------
 // CORS
 // ---------------------------------------------------------------------------
-// Only allow requests from the frontend origin.
-// Credentials: true is required so the browser sends the refresh cookie.
+// Bedroc uses a "public frontend, self-hosted backend" model:
+// The frontend is served from any origin (hosted, Vercel, Electron, PWA),
+// and users point it at their own backend URL.
+//
+// CORS_ORIGIN in .env controls the policy:
+//   - Set to a specific URL (e.g. https://bedroc.cagancalidag.com) to allow
+//     only that frontend (strictest — recommended for single-user servers).
+//   - Set to '*' to allow any origin (needed if you want any frontend to work).
+//   - Unset: defaults to allow any origin (open self-hosting model).
+//
+// Note: credentials:true + origin:'*' is not allowed by browsers, so we use
+// an origin callback that returns true for all origins instead.
+//
+// Security note: CORS is a browser protection, not a server auth mechanism.
+// All endpoints that need auth require a valid JWT — CORS only prevents
+// drive-by browser attacks, not API abuse from non-browser clients.
+const rawCorsOrigin = process.env.CORS_ORIGIN;
 await app.register(fastifyCors, {
-  origin: process.env.CORS_ORIGIN ?? false,
+  origin: rawCorsOrigin && rawCorsOrigin !== '*'
+    ? rawCorsOrigin           // specific origin: e.g. "https://bedroc.cagancalidag.com"
+    : (_origin, cb) => cb(null, true),  // any origin (public frontend model)
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
 });
@@ -154,7 +171,7 @@ app.log.info('Migrations complete.');
 // Redis connectivity check
 // ---------------------------------------------------------------------------
 app.log.info('Checking Redis connectivity…');
-const redis = getRedis();
+const redis = await getRedis();
 await redis.ping(); // throws if Redis is unreachable — fail fast
 app.log.info('Redis connected.');
 

--- a/server/src/plugins/redis.ts
+++ b/server/src/plugins/redis.ts
@@ -21,7 +21,7 @@ export async function getRedis(): Promise<RedisClientType> {
     socket: {
       reconnectStrategy: (retries) => Math.min(retries * 100, 3000),
     },
-  }) as RedisClientType;
+  }); //as RedisClientType;
 
   client.on('error', (err: Error) => console.error('[redis] Error:', err.message));
   client.on('connect', () => console.log('[redis] Connected.'));

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -31,7 +31,7 @@ import { z } from 'zod';
 import {
   createUser, getUserByUsername, getUserById,
   createSession, revokeSession, revokeAllSessions,
-  getSessionsForUser, revokeSessionById,
+  getSessionsForUser, revokeSessionById, updateUserCredentials,
 } from '../db/queries/users.js';
 import { hashToken, verifyAuth } from '../middleware/auth.js';
 import { getRedis } from '../plugins/redis.js';
@@ -208,7 +208,7 @@ function issueTokens(
   );
   const refreshToken = fastify.jwt.sign(
     { sub: userId, type: 'refresh' },
-    { secret: process.env.JWT_REFRESH_SECRET ?? 'changeme-refresh',
+    { key: process.env.JWT_REFRESH_SECRET ?? 'changeme-refresh',
       expiresIn: refreshTtl }
   );
 
@@ -472,6 +472,38 @@ export default async function authRoutes(fastify: FastifyInstance): Promise<void
     const { deleteUser } = await import('../db/queries/users.js');
     await deleteUser(userId);
     reply.clearCookie('bedroc_refresh', { path: '/api/auth/refresh' });
+    return reply.code(200).send({ ok: true });
+  });
+
+  // ── Change password (protected) ──────────────────────────────────────────
+  // Client re-derives everything with the new password and sends new material.
+  // The server atomically replaces srp_salt, srp_verifier, encrypted_dek, dek_salt.
+  // All existing sessions remain valid (access tokens are unaffected).
+
+  const ChangePasswordSchema = z.object({
+    srpSalt:      z.string().min(64).max(64),
+    srpVerifier:  z.string().min(1).max(2048),
+    encryptedDek: z.string().min(1),
+    dekSalt:      z.string().min(64).max(64),
+  });
+
+  fastify.post('/api/auth/change-password', async (req: FastifyRequest, reply: FastifyReply) => {
+    await verifyAuth(req, reply);
+    if (reply.sent) return;
+    const userId = (req as FastifyRequest & { userId: string }).userId;
+
+    const parse = ChangePasswordSchema.safeParse(req.body);
+    if (!parse.success) return reply.code(400).send({ error: 'Invalid request', details: parse.error.flatten() });
+    const { srpSalt, srpVerifier, encryptedDek, dekSalt } = parse.data;
+
+    await updateUserCredentials({
+      id: userId,
+      srpSalt:     Buffer.from(srpSalt, 'hex'),
+      srpVerifier: Buffer.from(srpVerifier, 'hex'),
+      encryptedDek,
+      dekSalt:     Buffer.from(dekSalt, 'hex'),
+    });
+
     return reply.code(200).send({ ok: true });
   });
 }


### PR DESCRIPTION
Add client-side sync conflict support and related infra: bump IndexedDB to v2 with a new `conflicts` store and helper APIs; detect conflicts in syncFromServer(), persist them, expose a reactive conflictsMap and provide resolveConflict() to choose local/server/custom merge. Implement change-password flow (re-derive master key, re-wrap DEK, update SRP verifier and server). Introduce a WebSocket client to receive real-time note updates and trigger sync. Misc: add bedroc nginx-static.conf and adjust bedroc Dockerfile, update .env.example and GUIDE with CORS guidance, add DEV-GUIDE.md, and include PWA service worker + vercel.json.