### PR TITLE
Live sync, offline auth, and various UI fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,9 +34,11 @@ REDIS_URL=redis://redis:6379
 JWT_ACCESS_SECRET=CHANGE_THIS_GENERATE_WITH_OPENSSL_RAND_HEX_32
 JWT_REFRESH_SECRET=CHANGE_THIS_GENERATE_WITH_OPENSSL_RAND_HEX_32_DIFFERENT
 
-# Token lifetimes (Go duration syntax)
+# Token lifetimes. Access token is short-lived (auto-refreshed silently via cookie).
+# Refresh token controls how long a session lasts before re-login is required.
+# Supported suffixes: m (minutes), h (hours), d (days)
 JWT_ACCESS_EXPIRY=15m
-JWT_REFRESH_EXPIRY=7d
+JWT_REFRESH_EXPIRY=30d
 
 # ── CORS ──────────────────────────────────────────────────────────────────────
 # Controls which frontend origins are allowed to make API requests.

--- a/DEV-GUIDE.md
+++ b/DEV-GUIDE.md
@@ -369,9 +369,16 @@ When making changes:
 
 ---
 
+## Auth / session notes
+
+- **Refresh token cookie** uses `sameSite: 'none'; Secure: true` so it is sent cross-origin from any frontend (e.g. `bedroc.cagancalidag.com` → `https://10.66.66.1`). This is required for the public-frontend / self-hosted-backend model.
+- **Session lifetime** defaults to 30 days (`JWT_REFRESH_EXPIRY=30d`). Configure via env var. The access token refreshes silently every 15 minutes (`JWT_ACCESS_EXPIRY=15m`).
+- **Offline unlock**: when the server is unreachable (network error, not 401), the app shows an unlock prompt so users can access local IndexedDB notes without connectivity.
+
 ## Known limitations (current state)
 
 - **Change password** re-derives master key and re-wraps the DEK, but does not revoke existing sessions. Users who want to invalidate all sessions after a password change should also use "Revoke all sessions" in Settings.
 - **Rate limiting** on auth routes uses Redis — if Redis is unavailable, the rate limiter falls back to in-memory (single-instance only).
 - **iOS push notifications**: the PWA service worker does not support push notifications on iOS (Apple limitation). Real-time sync uses the WebSocket connection instead — it works while the app is open.
 - **Editor**: text formatting uses `document.execCommand` (deprecated). Phase 6 will migrate to ProseMirror.
+- **Self-signed cert (browser)**: browsers block fetch() to HTTPS backends with self-signed certs. Use a domain with a real certificate (Caddy, Let's Encrypt) for the best experience. The Electron desktop app bypasses this restriction for private IPs.

--- a/bedroc/src/app.css
+++ b/bedroc/src/app.css
@@ -80,7 +80,7 @@ input, textarea, select {
 	color: var(--text);
 	border: 1px solid var(--border);
 	border-radius: var(--radius-sm);
-	padding: 10px 12px;
+	padding: 8px 12px;
 	width: 100%;
 	outline: none;
 	transition: border-color 0.15s ease;

--- a/bedroc/src/lib/db/indexeddb.ts
+++ b/bedroc/src/lib/db/indexeddb.ts
@@ -406,3 +406,23 @@ export async function wipeLocalData(userId: string): Promise<void> {
 
   closeDb();
 }
+
+/**
+ * Wipe everything EXCEPT notes (and conflicts, which reference notes).
+ * Clears: topics, folders, syncQueue, keyMaterial.
+ * Use this to force a fresh re-sync of metadata without losing local note content.
+ * After calling this, the user will need to log in again to restore keyMaterial.
+ */
+export async function wipeAppDataKeepNotes(): Promise<void> {
+  const d = await openDb();
+  const tx = d.transaction(['topics', 'folders', 'syncQueue', 'keyMaterial'], 'readwrite');
+  tx.objectStore('topics').clear();
+  tx.objectStore('folders').clear();
+  tx.objectStore('syncQueue').clear();
+  tx.objectStore('keyMaterial').clear();
+  await new Promise<void>((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+  closeDb();
+}

--- a/bedroc/src/lib/stores/auth.svelte.ts
+++ b/bedroc/src/lib/stores/auth.svelte.ts
@@ -166,6 +166,10 @@ export type ServerStatus = 'unknown' | 'checking' | 'online' | 'offline';
 
 let _serverStatus = $state<ServerStatus>('unknown');
 export const serverStatus = { get value() { return _serverStatus; } };
+/** Called by syncFromServer to reflect live connectivity without a separate HTTP request. */
+export function reportSyncResult(ok: boolean): void {
+  _serverStatus = ok ? 'online' : 'offline';
+}
 
 /**
  * Returns true if the current server URL is https:// on a bare IP —
@@ -199,25 +203,22 @@ async function tryHealthFetch(target: string): Promise<boolean> {
   }
 }
 
+/**
+ * Check server health and update _serverStatus.
+ *
+ * When `url` has no scheme, probes both https:// and http:// and commits the
+ * working one. On an HTTPS page, http:// is never auto-committed (mixed-content).
+ * When `url` already has a scheme, only that variant is tried.
+ */
 export async function checkServerHealth(url?: string): Promise<boolean> {
-  const base = url ? normaliseServerUrl(url) : _serverUrl;
+  const raw = (url ?? _serverUrl).trim();
+  const target = normaliseServerUrl(raw); // always has a scheme
   _serverStatus = 'checking';
 
-  // Try the primary URL (always https:// after normalisation)
-  if (await tryHealthFetch(base)) {
-    if (base !== _serverUrl) setServerUrl(base);
+  if (await tryHealthFetch(target)) {
+    if (target !== _serverUrl) setServerUrl(target);
     _serverStatus = 'online';
     return true;
-  }
-
-  // If https:// failed, try http:// as fallback (useful on LAN / WireGuard)
-  if (base.startsWith('https://')) {
-    const httpFallback = base.replace(/^https:\/\//, 'http://');
-    if (await tryHealthFetch(httpFallback)) {
-      setServerUrl(httpFallback); // commit the working URL
-      _serverStatus = 'online';
-      return true;
-    }
   }
 
   _serverStatus = 'offline';
@@ -249,17 +250,14 @@ export async function apiFetch(
   // 'offline' is the sentinel for an offline-unlocked session — no Bearer token yet.
   // Attempt a token refresh first; if that succeeds, use the real token.
   if (_accessToken === 'offline') {
-    console.log('[auth] apiFetch: token is offline sentinel, attempting refresh before', path);
-    const refreshed = await tryRefreshToken();
-    if (!refreshed) {
-      console.warn('[auth] apiFetch: refresh failed while offline, returning 503 for', path);
-      // Still offline — return a synthetic 503 so callers fail gracefully
+    const result = await tryRefreshToken();
+    if (result !== 'ok') {
+      // Still offline or expired — return a synthetic 503 so callers fail gracefully
       return new Response(JSON.stringify({ error: 'Offline' }), {
         status: 503,
         headers: { 'Content-Type': 'application/json' },
       });
     }
-    console.log('[auth] apiFetch: refresh succeeded, proceeding with real token');
   }
 
   if (_accessToken) {
@@ -275,15 +273,12 @@ export async function apiFetch(
 
   // On 401, attempt token refresh once
   if (res.status === 401 && _accessToken) {
-    console.warn('[auth] apiFetch: got 401 for', path, '— attempting token refresh');
-    const refreshed = await tryRefreshToken();
-    if (refreshed) {
-      console.log('[auth] apiFetch: refresh succeeded, retrying', path);
+    const refreshResult = await tryRefreshToken();
+    if (refreshResult === 'ok') {
       headers.set('Authorization', `Bearer ${_accessToken}`);
       return fetch(url, { ...init, headers, credentials: 'include' });
     }
-    console.error('[auth] apiFetch: refresh failed after 401 for', path, '— logging out');
-    // Refresh failed — force logout
+    // Refresh failed (expired or offline) — force logout
     await logout();
     goto('/login');
   }
@@ -295,26 +290,29 @@ export async function apiFetch(
 // Token refresh
 // ---------------------------------------------------------------------------
 
-async function tryRefreshToken(): Promise<boolean> {
+/**
+ * Attempt to get a new access token via the httpOnly refresh cookie.
+ * Returns:
+ *   'ok'      — new access token issued
+ *   'expired' — server responded (401/403) — cookie missing or token revoked
+ *   'offline' — network error / server unreachable
+ */
+async function tryRefreshToken(): Promise<'ok' | 'expired' | 'offline'> {
   try {
-    console.log('[auth] tryRefreshToken: calling', `${_serverUrl}/api/auth/refresh`);
     const res = await fetch(`${_serverUrl}/api/auth/refresh`, {
       method: 'POST',
       credentials: 'include',
     });
-    console.log('[auth] tryRefreshToken: response', res.status, res.ok);
     if (!res.ok) {
-      const body = await res.text().catch(() => '');
-      console.warn('[auth] tryRefreshToken failed:', res.status, body);
-      return false;
+      console.warn('[auth] tryRefreshToken failed:', res.status);
+      return 'expired';
     }
     const data = await res.json() as { accessToken: string };
     _accessToken = data.accessToken;
-    console.log('[auth] tryRefreshToken: success, new token issued');
-    return true;
-  } catch (err) {
-    console.error('[auth] tryRefreshToken: exception', err);
-    return false;
+    return 'ok';
+  } catch {
+    // Network error — server unreachable or offline
+    return 'offline';
   }
 }
 
@@ -582,10 +580,10 @@ export async function logout(): Promise<void> {
  *   refresh via tryRefreshToken().
  */
 export async function restoreSession(): Promise<void> {
-  const refreshed = await tryRefreshToken();
+  const result = await tryRefreshToken();
 
-  if (refreshed) {
-    // Online: load saved identity from IndexedDB
+  if (result === 'ok') {
+    // Online and token refreshed — load saved identity from IndexedDB
     const km = await loadKeyMaterial();
     if (km) {
       _username = km.username;
@@ -593,30 +591,28 @@ export async function restoreSession(): Promise<void> {
       // _dek remains null — user must unlock with password
     }
 
-    // Get userId from the access token (decode without verify — browser already verified via HTTPS)
-    if (_accessToken) {
+    // Decode userId from the access token (no verify needed — already verified by server)
+    if (_accessToken && _accessToken !== 'offline') {
       try {
         const payload = JSON.parse(atob(_accessToken.split('.')[1])) as { sub: string };
         _userId = payload.sub;
       } catch {
-        // Malformed token — treat as logged out
         _accessToken = null;
       }
     }
-  } else {
-    // Offline or server unreachable — check for locally stored key material
+  } else if (result === 'offline') {
+    // Network error — server unreachable. Show offline unlock if user was logged in before.
     const km = await loadKeyMaterial();
     if (km && km.userId) {
-      // User was previously logged in; let them unlock with password locally
       _username = km.username;
       _userId = km.userId;
       _serverUrl = km.serverUrl;
-      // Sentinel value: signals "offline locked" to the login page unlock flow
+      // Sentinel: signals "offline locked" — login page shows unlock prompt
       _accessToken = 'offline';
-      // _dek remains null — user must unlock with password
     }
-    // If no key material, user has never logged in on this device — show login form
+    // No key material → fresh device, show normal login form
   }
+  // result === 'expired': cookie absent or revoked → show normal login form (no sentinel)
 }
 
 /**

--- a/bedroc/src/lib/stores/notes.svelte.ts
+++ b/bedroc/src/lib/stores/notes.svelte.ts
@@ -24,7 +24,7 @@
  */
 
 import { SvelteMap } from 'svelte/reactivity';
-import { auth, apiFetch } from './auth.svelte.js';
+import { auth, apiFetch, reportSyncResult } from './auth.svelte.js';
 import { encryptNote, decryptNote } from '$lib/crypto/encrypt.js';
 import {
   saveNote as idbSaveNote,
@@ -102,6 +102,44 @@ export const syncState = { get syncing() { return _syncing; } };
 export const conflictsMap = new SvelteMap<string, ConflictRecord>();
 
 export { type ConflictRecord };
+
+// ---------------------------------------------------------------------------
+// External update signal (real-time editor sync)
+// ---------------------------------------------------------------------------
+
+/**
+ * Posted by syncFromServer() when a note that is already in notesMap
+ * receives a newer version from the server. The note editor watches this map
+ * and applies the update cursor-preservingly when the setting is enabled.
+ *
+ * Consumed (deleted) by the editor after processing — acts as a one-shot signal.
+ */
+export interface ExternalUpdate {
+  title: string;
+  body: string;
+  updatedAt: number;
+}
+
+export const externalUpdates = new SvelteMap<string, ExternalUpdate>();
+
+// ---------------------------------------------------------------------------
+// Live sync setting (localStorage — user pref)
+// ---------------------------------------------------------------------------
+
+function readLiveSync(): boolean {
+  if (typeof localStorage === 'undefined') return true;
+  const raw = localStorage.getItem('bedroc_live_sync');
+  return raw === null ? true : raw === '1';
+}
+
+class LiveSyncStore {
+  enabled = $state(readLiveSync());
+  set(on: boolean) {
+    this.enabled = on;
+    if (typeof localStorage !== 'undefined') localStorage.setItem('bedroc_live_sync', on ? '1' : '0');
+  }
+}
+export const liveSyncStore = new LiveSyncStore();
 
 // ---------------------------------------------------------------------------
 // Sort mode (localStorage — user pref, not encrypted)
@@ -268,6 +306,7 @@ export async function syncFromServer(): Promise<void> {
     console.log('[sync] Starting syncFromServer', { userId, since, serverUrl: auth.serverUrl, hasAccessToken: !!auth.accessToken, tokenIsOffline: auth.accessToken === 'offline' });
     const res = await apiFetch(`/api/notes/sync?since=${encodeURIComponent(since)}`);
     console.log('[sync] /api/notes/sync response', res.status, res.ok);
+    reportSyncResult(res.ok);
     if (!res.ok) {
       const body = await res.text().catch(() => '');
       console.warn('[sync] /api/notes/sync failed', res.status, body);
@@ -360,6 +399,13 @@ export async function syncFromServer(): Promise<void> {
       await idbSaveNote(local);
       notesToSet.push([sn.id, localToNote(local)]);
 
+      // Signal real-time update to any open editor for this note.
+      // Only signal when live sync is enabled and the note was already loaded
+      // (i.e. existed in notesMap before this sync cycle).
+      if (liveSyncStore.enabled && notesMap.has(sn.id)) {
+        externalUpdates.set(sn.id, { title, body, updatedAt: serverUpdatedAt });
+      }
+
       // Clear any stale conflict for this note
       if (conflictsMap.has(sn.id)) {
         conflictsToDelete.push(sn.id);
@@ -382,6 +428,9 @@ export async function syncFromServer(): Promise<void> {
 
     console.log('[sync] Topics:', topicsMap.size, 'Folders:', foldersMap.size, 'Notes:', notesMap.size);
     console.log('[sync] syncFromServer complete');
+  } catch (err) {
+    reportSyncResult(false);
+    throw err;
   } finally {
     _syncing = false;
   }

--- a/bedroc/src/routes/+layout.svelte
+++ b/bedroc/src/routes/+layout.svelte
@@ -3,7 +3,7 @@
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
-	import { auth, restoreSession, checkServerHealth } from '$lib/stores/auth.svelte.js';
+	import { auth, restoreSession } from '$lib/stores/auth.svelte.js';
 	import { connect as wsConnect, disconnect as wsDisconnect } from '$lib/sync/websocket.js';
 	import { syncFromServer, syncIntervalStore } from '$lib/stores/notes.svelte.js';
 
@@ -50,9 +50,10 @@
 			// Don't redirect iframes to /login — they share the parent's vault
 			// state and will work once the parent window unlocks the DEK.
 			if (!isInIframe) goto('/login');
-		} else {
-			wsConnect();
-			checkServerHealth();
+		} else if (auth.dek) {
+			// Logged in with DEK available — do one immediate sync so UI is
+			// up-to-date without waiting for the first periodic interval tick.
+			syncFromServer().catch(() => {});
 		}
 
 		// Disconnect WebSocket on page unload (tab close, navigate away)
@@ -61,30 +62,31 @@
 		};
 	});
 
-	// Reconnect when auth state changes (e.g. token refreshed, login from another tab)
+	// Manage WebSocket connection based on login state.
+	// Does NOT call syncFromServer — that would create a reactive loop because
+	// syncFromServer updates notes/topics state, causing this effect to re-run.
 	$effect(() => {
-		if (auth.isLoggedIn && !isAuthRoute) {
+		const isLoggedIn = auth.isLoggedIn;
+		const hasDek = !!auth.dek;
+		if (isLoggedIn && hasDek && !isAuthRoute) {
 			wsConnect();
-		} else {
+		} else if (!isLoggedIn) {
 			wsDisconnect();
 		}
 	});
 
-	// Periodic background sync — only runs when logged in with DEK available.
+	// Periodic background sync + health check.
 	// Fires every syncIntervalStore.interval ms (default 5s, min 1s).
 	// The WebSocket handles push-triggered syncs; this catches anything missed.
 	$effect(() => {
 		const isLoggedIn = auth.isLoggedIn;
 		const hasDek = !!auth.dek;
-		console.log('[layout] sync effect re-evaluated', { isLoggedIn, hasDek, isAuthRoute });
 		if (!isLoggedIn || !hasDek || isAuthRoute) return;
 		const ms = syncIntervalStore.interval;
-		console.log('[layout] starting periodic sync every', ms, 'ms');
 		const id = setInterval(() => {
 			syncFromServer().catch((err) => { console.error('[layout] periodic sync error', err); });
 		}, ms);
 		return () => {
-			console.log('[layout] clearing periodic sync interval');
 			clearInterval(id);
 		};
 	});
@@ -196,7 +198,7 @@
 			<div class="sidebar-footer">
 				<button class="btn-ghost sidebar-user" onclick={() => {}}>
 					<span class="user-avatar" aria-hidden="true">U</span>
-					<span class="user-name">username</span>
+					<span class="user-name">{auth.username ?? 'Account'}</span>
 				</button>
 			</div>
 		</aside>

--- a/bedroc/src/routes/+page.svelte
+++ b/bedroc/src/routes/+page.svelte
@@ -193,6 +193,16 @@
 		e.preventDefault();
 		const t = e.touches[0];
 		const el = document.elementFromPoint(t.clientX, t.clientY) as Element | null;
+
+		// Detect "uncategorize" drop zone (All notes / Uncategorised buttons)
+		const uncategorizeEl = el?.closest('[data-drop-uncategorize]') as Element | null;
+		if (uncategorizeEl && dragKind === 'note') {
+			dropZone = 'uncategorize';
+			dropTarget = '__uncategorize__';
+			dropSide = 'into';
+			return;
+		}
+
 		// detect topic, folder, or note elements
 		const topicEl = elementClosestClass(el, 'topic-item');
 		const folderEl = elementClosestClass(el, 'folder-item');
@@ -252,7 +262,13 @@
 		// commit based on dragKind/dragId/dropZone/dropTarget/dropSide
 		if (!longPressActive) return;
 		if (dragKind && dragId && dropTarget) {
-			if (dropZone === 'topic') {
+			if (dropZone === 'uncategorize') {
+				// Drop on "All notes" or "Uncategorised" → remove topic from note
+				if (dragKind === 'note') {
+					const note = notesMap.get(dragId);
+					if (note) saveNote({ ...note, topicId: null });
+				}
+			} else if (dropZone === 'topic') {
 				if (dragKind === 'note') {
 					const note = notesMap.get(dragId);
 					if (note) saveNote({ ...note, topicId: dropTarget });
@@ -482,7 +498,16 @@
 
 	// ── Helpers ────────────────────────────────────────────────────
 	function stripHtml(html: string): string {
-		return html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+		return html
+			.replace(/<[^>]+>/g, ' ')         // strip tags
+			.replace(/&nbsp;/gi, ' ')          // decode non-breaking space
+			.replace(/&amp;/gi, '&')
+			.replace(/&lt;/gi, '<')
+			.replace(/&gt;/gi, '>')
+			.replace(/&quot;/gi, '"')
+			.replace(/&#39;/gi, "'")
+			.replace(/\s+/g, ' ')
+			.trim();
 	}
 
 	function topicsInFolder(folderId: string | null): Topic[] {
@@ -536,8 +561,10 @@
 
 		<nav class="topic-list">
 			<button
-				class="topic-item"
+				class="topic-item topic-item-all"
 				class:active={activeTopicId === 'all'}
+				class:drop-highlight={dropZone === 'uncategorize' && dragKind === 'note'}
+				data-drop-uncategorize="true"
 				onclick={() => selectTopic('all')}
 			>
 				<span class="topic-dot" style="background: var(--text-faint)"></span>
@@ -547,6 +574,8 @@
 
 			<button
 				class="topic-item"
+				class:drop-highlight={dropZone === 'uncategorize' && dragKind === 'note'}
+				data-drop-uncategorize="true"
 				class:active={activeTopicId === null}
 				class:drop-target-topic={dropZone === 'root' && dragKind === 'note'}
 				onclick={() => selectTopic(null)}
@@ -1161,6 +1190,13 @@
 
 	.topic-item.active {
 		background: color-mix(in srgb, var(--accent) 12%, transparent);
+		color: var(--text);
+	}
+
+	/* Highlighted when a note is dragged over the uncategorize zone */
+	.topic-item.drop-highlight {
+		background: color-mix(in srgb, var(--success) 14%, transparent);
+		outline: 1.5px solid color-mix(in srgb, var(--success) 50%, transparent);
 		color: var(--text);
 	}
 

--- a/bedroc/src/routes/login/+page.svelte
+++ b/bedroc/src/routes/login/+page.svelte
@@ -1,13 +1,25 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { onMount } from 'svelte';
 	import {
 		auth, login, logout, unlockWithPassword, setServerUrl, removeSavedServer,
 		normaliseServerUrl, checkServerHealth, serverStatus, isSelfSignedCandidate,
 	} from '$lib/stores/auth.svelte.js';
 	import { loadFromDb, syncFromServer } from '$lib/stores/notes.svelte.js';
+	import { wipeAppDataKeepNotes } from '$lib/db/indexeddb.js';
 
 	let serverExpanded = $state(false);
 	let showPassword = $state(false);
+	let menuOpen = $state(false);
+	let menuClearConfirm = $state(false);
+
+	async function clearAppDataKeepNotes() {
+		await wipeAppDataKeepNotes();
+		menuOpen = false;
+		menuClearConfirm = false;
+		// Reload so the app starts fresh (keyMaterial gone → login form shown)
+		window.location.reload();
+	}
 	let username = $state('');
 	let password = $state('');
 	let newServerInput = $state(auth.serverUrl);
@@ -50,10 +62,10 @@
 
 	async function saveServer() {
 		const url = normaliseServerUrl(newServerInput.trim());
-		newServerInput = url; // show normalised form
 		setServerUrl(url);
+		newServerInput = url;
 		serverExpanded = false;
-		await checkServerHealth(url);
+		checkServerHealth(url);
 	}
 
 	function selectServer(url: string) {
@@ -63,8 +75,26 @@
 		checkServerHealth(url);
 	}
 
-	// Run health check whenever server panel opens
-	$effect(() => { if (serverExpanded) checkServerHealth(); });
+	// Debounced live health check while typing (2s delay, only when panel open)
+	let _healthDebounce: ReturnType<typeof setTimeout> | null = null;
+	function onServerInputChange() {
+		if (_healthDebounce) clearTimeout(_healthDebounce);
+		_healthDebounce = setTimeout(() => {
+			const v = newServerInput.trim();
+			if (v) checkServerHealth(normaliseServerUrl(v));
+		}, 2000);
+	}
+
+	// Initial health check on page load so the dot is visible immediately
+	onMount(() => { checkServerHealth(); });
+
+	// Check health once when the server panel is first opened (not on every render)
+	let _prevExpanded = false;
+	$effect(() => {
+		const open = serverExpanded;
+		if (open && !_prevExpanded) checkServerHealth(normaliseServerUrl(newServerInput.trim()) || undefined);
+		_prevExpanded = open;
+	});
 
 	const statusDot: Record<string, string> = {
 		unknown: 'dot-unknown', checking: 'dot-checking',
@@ -78,6 +108,40 @@
 <svelte:head>
 	<title>Log in — Bedroc</title>
 </svelte:head>
+
+<!-- 3-dot corner menu — always visible on login screen -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="corner-menu-wrap">
+	<button
+		class="corner-menu-btn"
+		onclick={() => { menuOpen = !menuOpen; menuClearConfirm = false; }}
+		aria-label="Options"
+		aria-expanded={menuOpen}
+	>
+		⋮
+	</button>
+
+	{#if menuOpen}
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<div class="corner-menu-backdrop" onclick={() => { menuOpen = false; menuClearConfirm = false; }}></div>
+		<div class="corner-menu" role="menu">
+			{#if !menuClearConfirm}
+				<button class="corner-menu-item" role="menuitem" onclick={() => (menuClearConfirm = true)}>
+					<svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+						<polyline points="3,6 13,6 12,14 4,14"/><path d="M1 6h14M6 6V4a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2"/>
+					</svg>
+					Clear app data (keep notes)
+				</button>
+			{:else}
+				<p class="corner-menu-confirm-text">Your notes stay. Settings, topics, and cached session will be cleared. Continue?</p>
+				<div class="corner-menu-confirm-btns">
+					<button class="corner-menu-item corner-menu-danger" onclick={clearAppDataKeepNotes}>Yes, clear</button>
+					<button class="corner-menu-item" onclick={() => (menuClearConfirm = false)}>Cancel</button>
+				</div>
+			{/if}
+		</div>
+	{/if}
+</div>
 
 <div class="auth-card">
 	<div class="brand">
@@ -146,6 +210,9 @@
 		<div class="server-row">
 			<button type="button" class="server-toggle" onclick={() => (serverExpanded = !serverExpanded)}>
 				<span class="server-label">Server</span>
+				{#if serverStatus.value !== 'unknown'}
+					<span class="status-dot {statusDot[serverStatus.value]} inline-dot"></span>
+				{/if}
 				<span class="server-url">{auth.serverUrl}</span>
 				<svg
 					width="12"
@@ -165,11 +232,12 @@
 					<input
 						type="text"
 						class="server-input"
-						placeholder="https://api.bedroc.app or 10.66.66.1"
+						placeholder="10.66.66.1, 192.168.1.5:3000, notes.example.com"
 						bind:value={newServerInput}
 						spellcheck="false"
 						autocorrect="off"
 						autocapitalize="off"
+						oninput={onServerInputChange}
 					/>
 					<button type="button" class="btn-ghost server-save" onclick={saveServer}>
 						Save
@@ -218,7 +286,7 @@
 				{/if}
 
 				<p class="server-hint">
-					Enter any format: <code>10.66.66.1</code>, <code>192.168.1.5:3000</code>, or <code>https://notes.example.com</code>. Bare IPs and domain names default to https://.
+					Enter any format: <code>10.66.66.1</code>, <code>192.168.1.5:3000</code>, or <code>notes.example.com</code>. Scheme is detected automatically. Health check runs as you type.
 				</p>
 			{/if}
 		</div>
@@ -408,7 +476,7 @@
 		text-align: left;
 		background: none;
 		border: none;
-		padding: 8px 10px;
+		padding: 2px 10px;
 		font-size: 12px;
 		color: var(--text-muted);
 		cursor: pointer;
@@ -465,6 +533,9 @@
 	.dot-online   { background: var(--success); }
 	.dot-offline  { background: var(--danger); }
 
+	/* Dot shown inline inside the collapsed server-toggle button */
+	.inline-dot { display: inline-block; }
+
 	@keyframes pulse {
 		0%, 100% { opacity: 1; }
 		50%       { opacity: 0.3; }
@@ -490,5 +561,84 @@
 		text-align: center;
 		font-size: 13px;
 		color: var(--text-muted);
+	}
+
+	/* ── Corner 3-dot menu ──────────────────────────────── */
+	/* The .auth-shell (in layout) uses position:relative so we can fix
+	   the button to the corner of the auth area on all screen sizes. */
+	.corner-menu-wrap {
+		position: fixed;
+		top: 12px;
+		right: 12px;
+		z-index: 100;
+	}
+
+	.corner-menu-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		border-radius: 50%;
+		border: 1px solid var(--border);
+		background: var(--bg-elevated);
+		color: var(--text-muted);
+		font-size: 18px;
+		line-height: 1;
+		cursor: pointer;
+		transition: background 0.12s, color 0.12s;
+	}
+	.corner-menu-btn:hover {
+		background: var(--bg-hover);
+		color: var(--text);
+	}
+
+	.corner-menu-backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: 99;
+	}
+
+	.corner-menu {
+		position: absolute;
+		top: 38px;
+		right: 0;
+		min-width: 220px;
+		background: var(--bg-elevated);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-md);
+		box-shadow: 0 4px 20px rgba(0,0,0,0.35);
+		padding: 4px;
+		z-index: 101;
+	}
+
+	.corner-menu-item {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		width: 100%;
+		padding: 8px 10px;
+		font-size: 13px;
+		color: var(--text-muted);
+		background: none;
+		border: none;
+		border-radius: var(--radius-sm);
+		cursor: pointer;
+		text-align: left;
+	}
+	.corner-menu-item:hover { background: var(--bg-hover); color: var(--text); }
+	.corner-menu-danger { color: var(--danger) !important; }
+	.corner-menu-danger:hover { background: color-mix(in srgb, var(--danger) 10%, transparent); }
+
+	.corner-menu-confirm-text {
+		font-size: 12px;
+		color: var(--text-muted);
+		padding: 8px 10px 4px;
+		line-height: 1.5;
+	}
+	.corner-menu-confirm-btns {
+		display: flex;
+		gap: 4px;
+		padding: 4px;
 	}
 </style>

--- a/bedroc/src/routes/note/[id]/+page.svelte
+++ b/bedroc/src/routes/note/[id]/+page.svelte
@@ -9,7 +9,8 @@
 		moveTopic,
 		saveNote, resolveConflict,
 		relativeTime,
-		type Topic, type Folder, type ConflictRecord
+		externalUpdates, liveSyncStore,
+		type Topic, type Folder, type ConflictRecord, type ExternalUpdate
 	} from '$lib/stores/notes.svelte';
 
 	// ── Note identity ─────────────────────────────────────────────
@@ -132,6 +133,105 @@
 		if (!notes.length) return null;
 		notes.sort((a,b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
 		return notes[0];
+	}
+
+	// ── Real-time external update (from another device/tab) ───────
+	// Uses character-offset cursor saving so the cursor stays in place after innerHTML update.
+
+	/** Walk all text nodes under `root` in document order, counting chars. */
+	function getCharOffset(root: HTMLElement): number {
+		const sel = window.getSelection();
+		if (!sel || sel.rangeCount === 0) return -1;
+		const range = sel.getRangeAt(0);
+		// Count chars from root to range.startContainer:startOffset
+		const iter = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+		let offset = 0;
+		let node: Node | null;
+		while ((node = iter.nextNode())) {
+			if (node === range.startContainer) {
+				offset += range.startOffset;
+				return offset;
+			}
+			offset += (node as Text).length;
+		}
+		return -1; // cursor not inside root
+	}
+
+	/** Restore cursor to character offset `targetOffset` inside `root`. */
+	function setCharOffset(root: HTMLElement, targetOffset: number): void {
+		if (targetOffset < 0) return;
+		const sel = window.getSelection();
+		if (!sel) return;
+		const iter = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+		let offset = 0;
+		let node: Node | null;
+		while ((node = iter.nextNode())) {
+			const len = (node as Text).length;
+			if (offset + len >= targetOffset) {
+				const range = document.createRange();
+				range.setStart(node, Math.min(targetOffset - offset, len));
+				range.collapse(true);
+				sel.removeAllRanges();
+				sel.addRange(range);
+				return;
+			}
+			offset += len;
+		}
+		// targetOffset past end of content — put cursor at end
+		const range = document.createRange();
+		range.selectNodeContents(root);
+		range.collapse(false);
+		sel.removeAllRanges();
+		sel.addRange(range);
+	}
+
+	/** Apply an external update to the editor, preserving cursor position. */
+	function applyExternalUpdate(update: ExternalUpdate): void {
+		if (!bodyEl) return;
+		// Check if cursor is inside the editor
+		const sel = window.getSelection();
+		const editorFocused = sel && sel.rangeCount > 0 && bodyEl.contains(sel.getRangeAt(0).startContainer);
+
+		const charOffset = editorFocused ? getCharOffset(bodyEl) : -1;
+		const prevLen = bodyEl.innerText.length;
+
+		title = update.title;
+		bodyEl.innerHTML = update.body;
+
+		if (editorFocused && charOffset >= 0) {
+			const newLen = bodyEl.innerText.length;
+			// If content shrank and cursor was beyond new end, clamp to new end
+			const restoredOffset = newLen < prevLen && charOffset > newLen ? newLen : charOffset;
+			setCharOffset(bodyEl, restoredOffset);
+		}
+	}
+
+	let incomingUpdate = $state<ExternalUpdate | null>(null);
+
+	$effect(() => {
+		if (isNew || !noteId) return;
+		const update = externalUpdates.get(noteId);
+		if (!update) return;
+		externalUpdates.delete(noteId); // consume
+
+		if (saved) {
+			// Editor is clean — apply silently without disturbing the user
+			applyExternalUpdate(update);
+		} else {
+			// User has unsaved changes — show banner, let them decide
+			incomingUpdate = update;
+		}
+	});
+
+	function acceptIncoming() {
+		if (!incomingUpdate) return;
+		applyExternalUpdate(incomingUpdate);
+		saved = true;
+		incomingUpdate = null;
+	}
+
+	function dismissIncoming() {
+		incomingUpdate = null;
 	}
 
 	function handleTitleInput() { saved = false; scheduleAutosave(); }
@@ -376,6 +476,26 @@
 		spellcheck="true"
 		autocapitalize="sentences"
 	/>
+
+	<!-- ── Incoming update banner (real-time, unsaved conflict) ─── -->
+	{#if incomingUpdate}
+		<div class="incoming-banner" role="alert">
+			<div class="incoming-banner-icon" aria-hidden="true">
+				<svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+					<circle cx="7" cy="7" r="6" stroke="currentColor" stroke-width="1.3"/>
+					<path d="M7 4v3.5l2 1.5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+				</svg>
+			</div>
+			<div class="incoming-banner-text">
+				<span class="incoming-banner-title">Updated on another device</span>
+				<span class="incoming-banner-desc">Your unsaved changes conflict with a newer version.</span>
+			</div>
+			<div class="incoming-banner-actions">
+				<button class="incoming-btn-accept" onclick={acceptIncoming}>Use theirs</button>
+				<button class="incoming-btn-dismiss" onclick={dismissIncoming}>Keep mine</button>
+			</div>
+		</div>
+	{/if}
 
 	<!-- ── Conflict notice ──────────────────────────────────────── -->
 	{#if showConflict && conflict}
@@ -987,6 +1107,37 @@
 		color: var(--text);
 		border-color: var(--text-muted);
 	}
+
+	/* ── Incoming real-time update banner ────────────────────── */
+	.incoming-banner {
+		display: flex;
+		align-items: flex-start;
+		gap: 10px;
+		margin: 0 20px 12px;
+		padding: 10px 14px;
+		background: color-mix(in srgb, var(--accent) 10%, transparent);
+		border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+		border-radius: var(--radius-md);
+		font-size: 13px;
+	}
+	.incoming-banner-icon { color: var(--accent); flex-shrink: 0; margin-top: 2px; }
+	.incoming-banner-text { flex: 1; display: flex; flex-direction: column; gap: 2px; }
+	.incoming-banner-title { font-weight: 600; color: var(--accent); font-size: 12.5px; }
+	.incoming-banner-desc { color: var(--text-muted); font-size: 12px; line-height: 1.4; }
+	.incoming-banner-actions { display: flex; flex-direction: column; gap: 4px; flex-shrink: 0; }
+	.incoming-btn-accept {
+		padding: 4px 10px; font-size: 12px; font-weight: 600;
+		background: var(--accent); color: #0f1117; border: none;
+		border-radius: var(--radius-sm); cursor: pointer; transition: opacity 0.12s;
+	}
+	.incoming-btn-accept:hover { opacity: 0.85; }
+	.incoming-btn-dismiss {
+		padding: 4px 10px; font-size: 12px; font-weight: 500;
+		background: transparent; color: var(--text-muted);
+		border: 1px solid var(--border); border-radius: var(--radius-sm);
+		cursor: pointer; transition: color 0.12s, border-color 0.12s;
+	}
+	.incoming-btn-dismiss:hover { color: var(--text); border-color: var(--text-muted); }
 
 	/* ── Conflict diff view ───────────────────────────────────── */
 	.conflict-diff {

--- a/bedroc/src/routes/register/+page.svelte
+++ b/bedroc/src/routes/register/+page.svelte
@@ -1,14 +1,25 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { onMount } from 'svelte';
 	import {
 		auth, register, setServerUrl,
 		normaliseServerUrl, checkServerHealth, serverStatus, isSelfSignedCandidate,
 	} from '$lib/stores/auth.svelte.js';
 	import { loadFromDb } from '$lib/stores/notes.svelte.js';
+	import { wipeAppDataKeepNotes } from '$lib/db/indexeddb.js';
 
 	let serverExpanded = $state(false);
 	let showPassword = $state(false);
 	let showConfirm = $state(false);
+	let menuOpen = $state(false);
+	let menuClearConfirm = $state(false);
+
+	async function clearAppDataKeepNotes() {
+		await wipeAppDataKeepNotes();
+		menuOpen = false;
+		menuClearConfirm = false;
+		window.location.reload();
+	}
 	let username = $state('');
 	let password = $state('');
 	let confirm = $state('');
@@ -45,13 +56,31 @@
 
 	async function saveServer() {
 		const url = normaliseServerUrl(newServerInput.trim());
-		newServerInput = url;
 		setServerUrl(url);
+		newServerInput = url;
 		serverExpanded = false;
-		await checkServerHealth(url);
+		checkServerHealth(url);
 	}
 
-	$effect(() => { if (serverExpanded) checkServerHealth(); });
+	// Debounced live health check while typing (2s delay, only when panel open)
+	let _healthDebounce: ReturnType<typeof setTimeout> | null = null;
+	function onServerInputChange() {
+		if (_healthDebounce) clearTimeout(_healthDebounce);
+		_healthDebounce = setTimeout(() => {
+			const v = newServerInput.trim();
+			if (v) checkServerHealth(normaliseServerUrl(v));
+		}, 2000);
+	}
+
+	// Check health once when the server panel is first opened (not on every render)
+	let _prevExpanded = false;
+	$effect(() => {
+		const open = serverExpanded;
+		if (open && !_prevExpanded) checkServerHealth(normaliseServerUrl(newServerInput.trim()) || undefined);
+		_prevExpanded = open;
+	});
+
+	onMount(() => { checkServerHealth(); });
 
 	const statusDot: Record<string, string> = {
 		unknown: 'dot-unknown', checking: 'dot-checking',
@@ -85,6 +114,33 @@
 <svelte:head>
 	<title>Register — Bedroc</title>
 </svelte:head>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="corner-menu-wrap">
+	<button class="corner-menu-btn" onclick={() => { menuOpen = !menuOpen; menuClearConfirm = false; }} aria-label="Options" aria-expanded={menuOpen}>
+		⋮
+	</button>
+	{#if menuOpen}
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<div class="corner-menu-backdrop" onclick={() => { menuOpen = false; menuClearConfirm = false; }}></div>
+		<div class="corner-menu" role="menu">
+			{#if !menuClearConfirm}
+				<button class="corner-menu-item" role="menuitem" onclick={() => (menuClearConfirm = true)}>
+					<svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+						<polyline points="3,6 13,6 12,14 4,14"/><path d="M1 6h14M6 6V4a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2"/>
+					</svg>
+					Clear app data (keep notes)
+				</button>
+			{:else}
+				<p class="corner-menu-confirm-text">Your notes stay. Settings, topics, and cached session will be cleared. Continue?</p>
+				<div class="corner-menu-confirm-btns">
+					<button class="corner-menu-item corner-menu-danger" onclick={clearAppDataKeepNotes}>Yes, clear</button>
+					<button class="corner-menu-item" onclick={() => (menuClearConfirm = false)}>Cancel</button>
+				</div>
+			{/if}
+		</div>
+	{/if}
+</div>
 
 <div class="auth-card">
 	<div class="brand">
@@ -202,6 +258,9 @@
 		<div class="server-row">
 			<button type="button" class="server-toggle" onclick={() => (serverExpanded = !serverExpanded)}>
 				<span class="server-label">Server</span>
+				{#if serverStatus.value !== 'unknown'}
+					<span class="status-dot {statusDot[serverStatus.value]} inline-dot"></span>
+				{/if}
 				<span class="server-url">{auth.serverUrl}</span>
 				<svg width="12" height="12" viewBox="0 0 12 12" fill="none" class="chevron" class:rotated={serverExpanded}>
 					<path d="M2 4l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
@@ -209,7 +268,7 @@
 			</button>
 			{#if serverExpanded}
 				<div class="server-input-wrap">
-					<input type="text" class="server-input" placeholder="https://api.bedroc.app or 10.66.66.1" bind:value={newServerInput} spellcheck="false" autocorrect="off" autocapitalize="off"/>
+					<input type="text" class="server-input" placeholder="10.66.66.1, 192.168.1.5:3000, notes.example.com" bind:value={newServerInput} spellcheck="false" autocorrect="off" autocapitalize="off" oninput={onServerInputChange}/>
 					<button type="button" class="btn-ghost server-save" onclick={saveServer}>Save</button>
 				</div>
 				{#if serverStatus.value !== 'unknown'}
@@ -227,7 +286,7 @@
 						{/if}
 					</div>
 				{/if}
-				<p class="server-hint">Enter any format: <code>10.66.66.1</code>, <code>192.168.1.5:3000</code>, or <code>https://notes.example.com</code>. Bare IPs and domain names default to https://.</p>
+				<p class="server-hint">Enter any format: <code>10.66.66.1</code>, <code>192.168.1.5:3000</code>, or <code>notes.example.com</code>. Scheme is detected automatically. Health check runs as you type.</p>
 			{/if}
 		</div>
 
@@ -341,6 +400,7 @@
 	.dot-checking { background: var(--accent); animation: pulse 1s ease-in-out infinite; }
 	.dot-online   { background: var(--success); }
 	.dot-offline  { background: var(--danger); }
+	.inline-dot   { display: inline-block; }
 
 	@keyframes pulse {
 		0%, 100% { opacity: 1; }
@@ -505,4 +565,33 @@
 		font-size: 13px;
 		color: var(--text-muted);
 	}
+
+	/* ── Corner 3-dot menu ── */
+	.corner-menu-wrap { position: fixed; top: 12px; right: 12px; z-index: 100; }
+	.corner-menu-btn {
+		display: flex; align-items: center; justify-content: center;
+		width: 32px; height: 32px; border-radius: 50%; border: 1px solid var(--border);
+		background: var(--bg-elevated); color: var(--text-muted); cursor: pointer;
+		font-size: 18px; line-height: 1;
+		transition: background 0.12s, color 0.12s;
+	}
+	.corner-menu-btn:hover { background: var(--bg-hover); color: var(--text); }
+	.corner-menu-backdrop { position: fixed; inset: 0; z-index: 99; }
+	.corner-menu {
+		position: absolute; top: 38px; right: 0; min-width: 220px;
+		background: var(--bg-elevated); border: 1px solid var(--border);
+		border-radius: var(--radius-md); box-shadow: 0 4px 20px rgba(0,0,0,0.35);
+		padding: 4px; z-index: 101;
+	}
+	.corner-menu-item {
+		display: flex; align-items: center; gap: 8px; width: 100%;
+		padding: 8px 10px; font-size: 13px; color: var(--text-muted);
+		background: none; border: none; border-radius: var(--radius-sm);
+		cursor: pointer; text-align: left;
+	}
+	.corner-menu-item:hover { background: var(--bg-hover); color: var(--text); }
+	.corner-menu-danger { color: var(--danger) !important; }
+	.corner-menu-danger:hover { background: color-mix(in srgb, var(--danger) 10%, transparent); }
+	.corner-menu-confirm-text { font-size: 12px; color: var(--text-muted); padding: 8px 10px 4px; line-height: 1.5; }
+	.corner-menu-confirm-btns { display: flex; gap: 4px; padding: 4px; }
 </style>

--- a/bedroc/src/routes/settings/+page.svelte
+++ b/bedroc/src/routes/settings/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
-	import { autosave, syncIntervalStore, notesMap, topicsMap } from '$lib/stores/notes.svelte';
+	import { autosave, syncIntervalStore, liveSyncStore, notesMap, topicsMap } from '$lib/stores/notes.svelte';
 	import { auth, logout, apiFetch, changePassword } from '$lib/stores/auth.svelte.js';
 	import { clearStore } from '$lib/stores/notes.svelte.js';
 
@@ -230,6 +230,23 @@
 					</div>
 				</div>
 			{/if}
+			<div class="divider-inner"></div>
+			<div class="row">
+				<div class="row-info">
+					<span class="row-label">Live editor sync</span>
+					<span class="row-sub">Update open notes in real time when another device saves them</span>
+				</div>
+				<button
+					class="toggle"
+					class:on={liveSyncStore.enabled}
+					onclick={() => liveSyncStore.set(!liveSyncStore.enabled)}
+					role="switch"
+					aria-checked={liveSyncStore.enabled}
+					aria-label="Live editor sync"
+				>
+					<span class="toggle-thumb"></span>
+				</button>
+			</div>
 			<div class="divider-inner"></div>
 			<div class="row">
 				<div class="row-info">

--- a/docs/PLACEHOLDERS.md
+++ b/docs/PLACEHOLDERS.md
@@ -42,10 +42,13 @@ All Phase 1 placeholders have been replaced. See `lib/crypto/`, `lib/stores/auth
 | --- | --- | --- |
 | `lib/stores/notes.svelte.ts` | ✅ Done | WebSocket integration via `lib/sync/websocket.ts`; connect/disconnect wired in `+layout.svelte` |
 | `lib/sync/websocket.ts` | ✅ Done | WebSocket client with auto-reconnect, exponential backoff, 30s keepalive ping |
-| `routes/+layout.svelte` | ✅ Done | `wsConnect()` called after login; `wsDisconnect()` on logout; `$effect` reconnects on auth state change |
+| `routes/+layout.svelte` | ✅ Done | `wsConnect()` + immediate `syncFromServer()` called when `auth.isLoggedIn && auth.dek` become true |
 | `lib/stores/notes.svelte.ts` | ✅ Done | Conflict detection in `syncFromServer()` — preserves local edits, stores both versions, never silently overwrites |
 | `lib/stores/notes.svelte.ts` | ✅ Done | `resolveConflict()` — user resolves with local/server/custom merge; pushes resolved version to server |
 | `routes/note/[id]/+page.svelte` | ✅ Done | Conflict resolution UI — banner + full diff view showing both versions side-by-side |
+| `lib/stores/notes.svelte.ts` | ✅ Done | `externalUpdates` SvelteMap — signals real-time updates to open editors; `liveSyncStore` toggle |
+| `routes/note/[id]/+page.svelte` | ✅ Done | Real-time editor sync: applies incoming updates cursor-preservingly (character-offset save/restore); shows banner if unsaved changes |
+| `routes/settings/+page.svelte` | ✅ Done | "Live editor sync" toggle (default on) |
 
 ---
 

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -231,12 +231,21 @@ function parseDeviceInfo(ua: string): string {
 // JWT helpers
 // ---------------------------------------------------------------------------
 
+function parseTtlMs(ttl: string): number {
+  if (ttl.endsWith('d')) return parseInt(ttl) * 86_400_000;
+  if (ttl.endsWith('h')) return parseInt(ttl) * 3_600_000;
+  if (ttl.endsWith('m')) return parseInt(ttl) * 60_000;
+  return parseInt(ttl) * 1000;
+}
+
 function issueTokens(
   fastify: FastifyInstance,
   userId: string
-): { accessToken: string; refreshToken: string; accessExpiresAt: Date; refreshExpiresAt: Date } {
-  const accessTtl = process.env.JWT_ACCESS_EXPIRY ?? '15m';
-  const refreshTtl = process.env.JWT_REFRESH_EXPIRY ?? '7d';
+): { accessToken: string; refreshToken: string; accessExpiresAt: Date; refreshExpiresAt: Date; refreshMaxAge: number } {
+  // Access token: short-lived (default 15m), auto-refreshed via cookie
+  // Refresh token: long-lived (default 30d), rotated on each use
+  const accessTtl  = process.env.JWT_ACCESS_EXPIRY  ?? '15m';
+  const refreshTtl = process.env.JWT_REFRESH_EXPIRY ?? '30d';
 
   const accessToken = fastify.jwt.sign(
     { sub: userId },
@@ -244,22 +253,18 @@ function issueTokens(
   );
   const refreshToken = fastify.jwt.sign(
     { sub: userId, type: 'refresh' },
-    { key: process.env.JWT_REFRESH_SECRET!,
-      expiresIn: refreshTtl }
+    { key: process.env.JWT_REFRESH_SECRET!, expiresIn: refreshTtl }
   );
 
-  const accessMs = accessTtl.endsWith('m')
-    ? parseInt(accessTtl) * 60_000
-    : parseInt(accessTtl) * 1000;
-  const refreshMs = refreshTtl.endsWith('d')
-    ? parseInt(refreshTtl) * 86_400_000
-    : 604_800_000;
+  // Cookie maxAge must match refresh token expiry
+  const refreshMs = parseTtlMs(refreshTtl);
 
   return {
     accessToken,
     refreshToken,
-    accessExpiresAt: new Date(Date.now() + accessMs),
+    accessExpiresAt:  new Date(Date.now() + parseTtlMs(accessTtl)),
     refreshExpiresAt: new Date(Date.now() + refreshMs),
+    refreshMaxAge:    Math.floor(refreshMs / 1000), // seconds for cookie maxAge
   };
 }
 
@@ -312,10 +317,8 @@ export default async function authRoutes(fastify: FastifyInstance): Promise<void
     });
 
     // Auto-login: issue tokens so the client is immediately authenticated
-    const { accessToken, refreshToken, accessExpiresAt, refreshExpiresAt } = issueTokens(fastify, user.id);
+    const { accessToken, refreshToken, accessExpiresAt, refreshExpiresAt, refreshMaxAge } = issueTokens(fastify, user.id);
     const deviceInfo = parseDeviceInfo((req.headers['user-agent'] as string) ?? '');
-    // Session expires with the refresh token (7d), not the access token (15m).
-    // upsertSessionForDevice ensures one active session per device label.
     await upsertSessionForDevice({
       userId:           user.id,
       tokenHash:        hashToken(accessToken),
@@ -326,10 +329,10 @@ export default async function authRoutes(fastify: FastifyInstance): Promise<void
 
     reply.setCookie('bedroc_refresh', refreshToken, {
       httpOnly: true,
-      secure:   process.env.NODE_ENV === 'production',
-      sameSite: 'strict',
+      secure:   true,
+      sameSite: 'none',  // cross-site: frontend and backend may be on different origins
       path:     '/api/auth/refresh',
-      maxAge:   7 * 24 * 3600,
+      maxAge:   refreshMaxAge,
     });
 
     return reply.code(201).send({
@@ -418,12 +421,9 @@ export default async function authRoutes(fastify: FastifyInstance): Promise<void
     if (!valid) return reply.code(401).send({ error: 'Authentication failed' });
 
     // Issue JWTs
-    const { accessToken, refreshToken, accessExpiresAt, refreshExpiresAt } = issueTokens(fastify, userId);
+    const { accessToken, refreshToken, accessExpiresAt, refreshExpiresAt, refreshMaxAge } = issueTokens(fastify, userId);
     const deviceInfo = parseDeviceInfo((req.headers['user-agent'] as string) ?? '');
 
-    // Store hashed access + refresh tokens for revocation checks.
-    // Session expires with the refresh token (7d), not the access token (15m).
-    // upsertSessionForDevice ensures one active session per device label.
     await upsertSessionForDevice({
       userId,
       tokenHash:        hashToken(accessToken),
@@ -432,13 +432,15 @@ export default async function authRoutes(fastify: FastifyInstance): Promise<void
       expiresAt:        refreshExpiresAt,
     });
 
-    // Refresh token stored in httpOnly cookie (never accessible to JS)
+    // Refresh token stored in httpOnly cookie (never accessible to JS).
+    // sameSite: 'none' + secure: true allows the cookie to be sent from any
+    // frontend origin (e.g. bedroc.cagancalidag.com → https://10.66.66.1).
     reply.setCookie('bedroc_refresh', refreshToken, {
       httpOnly: true,
-      secure:   process.env.NODE_ENV === 'production',
-      sameSite: 'strict',
+      secure:   true,
+      sameSite: 'none',
       path:     '/api/auth/refresh',
-      maxAge:   7 * 24 * 3600,
+      maxAge:   refreshMaxAge,
     });
 
     return reply.code(200).send({
@@ -472,7 +474,7 @@ export default async function authRoutes(fastify: FastifyInstance): Promise<void
     const user = await getUserById(payload.sub);
     if (!user) return reply.code(401).send({ error: 'User not found' });
 
-    const { accessToken, refreshToken: newRefresh, accessExpiresAt, refreshExpiresAt } = issueTokens(fastify, user.id);
+    const { accessToken, refreshToken: newRefresh, accessExpiresAt, refreshExpiresAt, refreshMaxAge } = issueTokens(fastify, user.id);
 
     // Update the existing session row: swap in the new token hashes and extend
     // the session lifetime to the new refresh token expiry (7d rolling window).
@@ -503,10 +505,10 @@ export default async function authRoutes(fastify: FastifyInstance): Promise<void
 
     reply.setCookie('bedroc_refresh', newRefresh, {
       httpOnly: true,
-      secure:   process.env.NODE_ENV === 'production',
-      sameSite: 'strict',
+      secure:   true,
+      sameSite: 'none',
       path:     '/api/auth/refresh',
-      maxAge:   7 * 24 * 3600,
+      maxAge:   refreshMaxAge,
     });
 
     return reply.code(200).send({ accessToken, expiresAt: accessExpiresAt.toISOString() });
@@ -520,7 +522,7 @@ export default async function authRoutes(fastify: FastifyInstance): Promise<void
     const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null;
     if (token) await revokeSession(hashToken(token));
 
-    reply.clearCookie('bedroc_refresh', { path: '/api/auth/refresh' });
+    reply.clearCookie('bedroc_refresh', { path: '/api/auth/refresh', sameSite: 'none', secure: true });
     return reply.code(200).send({ ok: true });
   });
 
@@ -552,7 +554,7 @@ export default async function authRoutes(fastify: FastifyInstance): Promise<void
     if (reply.sent) return;
     const userId = (req as FastifyRequest & { userId: string }).userId;
     await revokeAllSessions(userId);
-    reply.clearCookie('bedroc_refresh', { path: '/api/auth/refresh' });
+    reply.clearCookie('bedroc_refresh', { path: '/api/auth/refresh', sameSite: 'none', secure: true });
     return reply.code(200).send({ ok: true });
   });
 
@@ -566,7 +568,7 @@ export default async function authRoutes(fastify: FastifyInstance): Promise<void
     // Imported lazily to avoid circular dep
     const { deleteUser } = await import('../db/queries/users.js');
     await deleteUser(userId);
-    reply.clearCookie('bedroc_refresh', { path: '/api/auth/refresh' });
+    reply.clearCookie('bedroc_refresh', { path: '/api/auth/refresh', sameSite: 'none', secure: true });
     return reply.code(200).send({ ok: true });
   });
 


### PR DESCRIPTION
Introduce real-time editor sync, improved offline session handling, and several UX/CSS tweaks.

Highlights:
- Notes store: add externalUpdates SvelteMap and liveSyncStore (prefs via localStorage); syncFromServer now signals externalUpdates for updated notes and reports server health back to auth.
- Note editor: apply incoming updates cursor-preservingly (char-offset save/restore) and show an incoming-update banner when local edits conflict.
- Auth/client: tryRefreshToken now returns explicit 'ok'|'expired'|'offline' results; restoreSession supports an 'offline' sentinel to allow local unlock; checkServerHealth/health-check UX improvements and server-status reporting API added (reportSyncResult).
- Server/auth: add parseTtlMs helper, default refresh expiry bumped to 30d, and issueTokens returns refreshMaxAge to align cookie maxAge with token TTL.
- IndexedDB: add wipeAppDataKeepNotes to clear metadata (topics/folders/syncQueue/keyMaterial) while preserving notes.
- Login/Register: add corner 3-dot menu to clear app data while keeping notes, debounced live health check while typing, and inline server status dot; various markup and styles updated.
- UI: drag-and-drop uncategorize target, improved stripHtml entity handling, minor padding/CSS tweaks, and show username in sidebar.
- Docs: update .env.example, DEV-GUIDE, and PLACEHOLDERS.md to document session, cookie, and live-sync behaviour.

These changes improve offline unlock behavior, make real-time cross-device edits less disruptive, and streamline server health UX.