### PR TITLE
Add session metadata, rate limits, and editor UX

### DIFF
--- a/DEV-GUIDE.md
+++ b/DEV-GUIDE.md
@@ -201,14 +201,16 @@ Migrations run automatically on every server startup (`runMigrations()` in `serv
 Migration files live at `server/src/db/migrations/` and are numbered sequentially:
 
 ```text
-001_init.sql   — users, sessions, notes, topics, folders tables
-002_*.sql      — (future migrations)
+001_init.sql              — users, sessions, notes, topics, folders tables
+002_session_refresh_hash  — adds refresh_token_hash to sessions (token rotation)
+003_session_metadata      — adds login_ip and last_used_at to sessions
 ```
 
 To add a migration:
 
-1. Create `server/src/db/migrations/002_description.sql`
-2. The migration runner automatically picks up new files on next restart
+1. Create `server/src/db/migrations/004_description.sql`
+2. Add the filename to the `migrations` array in `server/src/db/client.ts`
+3. The migration runs automatically on next server start
 
 To run migrations manually (e.g. for inspection):
 
@@ -374,11 +376,32 @@ When making changes:
 - **Refresh token cookie** uses `sameSite: 'none'; Secure: true` so it is sent cross-origin from any frontend (e.g. `bedroc.cagancalidag.com` → `https://10.66.66.1`). This is required for the public-frontend / self-hosted-backend model.
 - **Session lifetime** defaults to 30 days (`JWT_REFRESH_EXPIRY=30d`). Configure via env var. The access token refreshes silently every 15 minutes (`JWT_ACCESS_EXPIRY=15m`).
 - **Offline unlock**: when the server is unreachable (network error, not 401), the app shows an unlock prompt so users can access local IndexedDB notes without connectivity.
+- **Session metadata**: each session records `login_ip` (from `X-Forwarded-For` or direct IP) and `last_used_at` (updated on every token refresh). The Settings page shows "This device" next to the current session, login timestamp, IP, and expiry. Older sessions without these fields show gracefully without errors.
+- **Device detection**: `parseDeviceInfo()` in `server/src/routes/auth.ts` parses the User-Agent string into a human-readable label. Handles: Edge (desktop `Edg/`, mobile `EdgA/`), Chrome/CrOS, Firefox, Safari, Opera, Samsung Browser, Electron. CrOS is detected before Mac/Linux to avoid false-positive "Linux" labels.
+
+## Rate limits
+
+Rate limits are configured per-route in `server/src/routes/` and globally in `server/src/index.ts`.
+
+| Route | Limit | Reason |
+| --- | --- | --- |
+| Global fallback | 500 req/min | All other authenticated routes |
+| `GET /api/notes/sync` | 200 req/min | 0.5 s minimum sync interval = 120 req/min |
+| `PUT /api/notes/:id` | 200 req/min | Rapid typing + short autosave intervals |
+| `GET /api/notes`, `GET /api/notes/:id` | 120 req/min | General note reads |
+| `PUT /api/topics/:id`, `PUT /api/folders/:id` | 120 req/min | Rapid drag-to-reorder |
+| `GET /api/topics`, `GET /api/folders` | 120 req/min | Sync reads |
+| `DELETE /api/notes/:id` | 60 req/min | Delete operations |
+| `POST /api/auth/register` | 5 req/min | Anti-spam |
+| `POST /api/auth/login/init` | 10 req/min | Brute-force protection |
+| `POST /api/auth/login/verify` | 10 req/min | Brute-force protection |
+
+To change a per-route limit, update `config: { rateLimit: { max: N, timeWindow: '1 minute' } }` on that route handler. To change the global fallback, update `max` in the `fastifyRateLimit` registration in `server/src/index.ts`.
 
 ## Known limitations (current state)
 
 - **Change password** re-derives master key and re-wraps the DEK, but does not revoke existing sessions. Users who want to invalidate all sessions after a password change should also use "Revoke all sessions" in Settings.
 - **Rate limiting** on auth routes uses Redis — if Redis is unavailable, the rate limiter falls back to in-memory (single-instance only).
 - **iOS push notifications**: the PWA service worker does not support push notifications on iOS (Apple limitation). Real-time sync uses the WebSocket connection instead — it works while the app is open.
-- **Editor**: text formatting uses `document.execCommand` (deprecated). Phase 6 will migrate to ProseMirror.
+- **Editor**: text formatting uses `document.execCommand` (deprecated). Phase 6 will migrate to ProseMirror. Current editor supports bold/italic/underline/strikethrough/lists/font-size/color/clear-formatting/paste-without-formatting.
 - **Self-signed cert (browser)**: browsers block fetch() to HTTPS backends with self-signed certs. Use a domain with a real certificate (Caddy, Let's Encrypt) for the best experience. The Electron desktop app bypasses this restriction for private IPs.

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -535,6 +535,50 @@ Add this line to back up every day at 3am:
 0 3 * * * cd /path/to/Bedroc && docker compose exec -T postgres pg_dump -U postgres bedroc | gzip > /backups/bedroc-$(date +\%Y\%m\%d).sql.gz
 ```
 
+### Adjusting rate limits
+
+Rate limits protect the server from abuse and brute-force attacks. The defaults are generous for normal use. If you are hitting limits (e.g. getting 429 errors), you can increase them.
+
+**Global fallback** — covers all authenticated routes not listed below. Edit `server/src/index.ts`:
+
+```ts
+await app.register(fastifyRateLimit, {
+  max: 500,          // ← change this number
+  timeWindow: '1 minute',
+```
+
+**Per-route limits** — defined on individual route handlers in `server/src/routes/notes.ts` and `server/src/routes/auth.ts`. Look for `config: { rateLimit: { max: N } }` on the route you want to change:
+
+```ts
+// Example: increase note sync limit
+{
+  method: 'GET',
+  url: '/api/notes/sync',
+  config: { rateLimit: { max: 200, timeWindow: '1 minute' } },  // ← change max here
+  ...
+}
+```
+
+Current defaults:
+
+| Route | Default limit |
+| --- | --- |
+| Global fallback (all auth routes) | 500 req/min |
+| `GET /api/notes/sync` | 200 req/min |
+| `PUT /api/notes/:id` | 200 req/min |
+| `GET /api/notes` | 120 req/min |
+| `PUT /api/topics/:id`, `PUT /api/folders/:id` | 120 req/min |
+| `GET /api/topics`, `GET /api/folders` | 120 req/min |
+| `DELETE /api/notes/:id` | 60 req/min |
+| `POST /api/auth/register` | 5 req/min |
+| `POST /api/auth/login/init` and `/verify` | 10 req/min |
+
+After changing limits, rebuild the server container:
+
+```bash
+docker compose up -d --build server
+```
+
 ---
 
 ## Troubleshooting

--- a/bedroc/src/routes/+layout.svelte
+++ b/bedroc/src/routes/+layout.svelte
@@ -54,6 +54,10 @@
 				// Iframe: userId is set from the refresh token even without a DEK.
 				// Load notes from the shared IndexedDB so the pane shows content.
 				if (auth.userId) loadFromDb().catch(() => {});
+				// Show the server status dot by running a health check.
+				import('$lib/stores/auth.svelte.js').then(({ checkServerHealth }) => {
+					checkServerHealth().catch(() => {});
+				});
 			}
 		} else if (auth.dek) {
 			// Logged in with DEK available — do one immediate sync so UI is
@@ -388,7 +392,8 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		padding: 24px 16px;
+		/* Top safe area ensures the login form isn't under the status bar on iOS PWA */
+		padding: max(env(safe-area-inset-top, 0px), 24px) 16px max(env(safe-area-inset-bottom, 0px), 24px);
 		background: var(--bg);
 	}
 

--- a/bedroc/src/routes/note/[id]/+page.svelte
+++ b/bedroc/src/routes/note/[id]/+page.svelte
@@ -96,35 +96,47 @@
 		autosaveTimer = setTimeout(doSave, autosave.interval);
 	}
 
+	// Prevents concurrent saves from racing each other.
+	let _saving = false;
+
 	async function doSave() {
 		if (saved) return;
+		if (_saving) return; // already in flight — the next autosave will catch unsaved changes
+		_saving = true;
+
+		// Snapshot body + cursor BEFORE any await — nothing can change the DOM
+		// between these two lines and the async work below.
 		const body = bodyEl?.innerHTML ?? '';
+		const savedPosition = bodyEl ? saveCursorPosition(bodyEl) : null;
 
-		// Capture cursor position before save — notesMap.set() inside saveNote
-		// can trigger Svelte effect scheduling which may lose the selection.
-		const savedCharOffset = bodyEl ? getCharOffset(bodyEl) : -1;
+		try {
+			if (isNew) {
+				const id = await createNote(null);
+				const created = notesMap.get(id)!;
+				await saveNote({ ...created, title: dedupTitle(title.trim() || 'Untitled', null, id), body });
+				saved = true;
+				goto(`/note/${id}`, { replaceState: true });
+			} else {
+				const existing = notesMap.get(noteId!);
+				if (!existing) return;
+				await saveNote({ ...existing, title: dedupTitle(title.trim() || 'Untitled', existing.topicId, existing.id), body });
+				saved = true;
+				_lastSaveAt = Date.now();
+			}
 
-		if (isNew) {
-			const id = await createNote(null);
-			const created = notesMap.get(id)!;
-			await saveNote({ ...created, title: dedupTitle(title.trim() || 'Untitled', null, id), body });
-			saved = true;
-			goto(`/note/${id}`, { replaceState: true });
-		} else {
-			const existing = notesMap.get(noteId!);
-			if (!existing) return;
-			await saveNote({ ...existing, title: dedupTitle(title.trim() || 'Untitled', existing.topicId, existing.id), body });
-			saved = true;
-		}
-
-		// Restore cursor if the editor still has focus and position is known.
-		// Use requestAnimationFrame so any pending Svelte DOM updates flush first.
-		if (bodyEl && savedCharOffset >= 0 && document.activeElement === bodyEl) {
-			requestAnimationFrame(() => {
-				if (bodyEl && document.activeElement === bodyEl) {
-					setCharOffset(bodyEl, savedCharOffset);
-				}
-			});
+			// Restore cursor after save.  The save touches IDB + reactivity but
+			// should NOT touch bodyEl.innerHTML (the $effect guard prevents that),
+			// so we only need to restore if the browser moved the caret (it can
+			// after certain layout-triggering async operations).
+			if (savedPosition && bodyEl && document.activeElement === bodyEl) {
+				requestAnimationFrame(() => {
+					if (savedPosition && bodyEl && document.activeElement === bodyEl) {
+						restoreCursorPosition(bodyEl, savedPosition);
+					}
+				});
+			}
+		} finally {
+			_saving = false;
 		}
 	}
 
@@ -154,49 +166,76 @@
 	// ── Real-time external update (from another device/tab) ───────
 	// Uses character-offset cursor saving so the cursor stays in place after innerHTML update.
 
-	/** Walk all text nodes under `root` in document order, counting chars. */
-	function getCharOffset(root: HTMLElement): number {
-		const sel = window.getSelection();
-		if (!sel || sel.rangeCount === 0) return -1;
-		const range = sel.getRangeAt(0);
-		// Count chars from root to range.startContainer:startOffset
-		const iter = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
-		let offset = 0;
-		let node: Node | null;
-		while ((node = iter.nextNode())) {
-			if (node === range.startContainer) {
-				offset += range.startOffset;
-				return offset;
-			}
-			offset += (node as Text).length;
-		}
-		return -1; // cursor not inside root
+	// ── Cursor preservation ───────────────────────────────────────
+	// We use a path-based approach rather than char-offset.  A path is an array
+	// of child indices from root to the caret node.  This handles:
+	//   - Cursor inside empty elements (empty <li>, after <br>)
+	//   - Cursor in text nodes
+	//   - Mixed content (text + inline elements)
+	// After an innerHTML replacement, the structure should be identical (same
+	// HTML string), so the path restores correctly.
+
+	interface CursorPos {
+		path: number[];        // child indices from root to the container node
+		offset: number;        // offset inside that container (char offset for text, child index for element)
+		isCollapsed: boolean;
 	}
 
-	/** Restore cursor to character offset `targetOffset` inside `root`. */
-	function setCharOffset(root: HTMLElement, targetOffset: number): void {
-		if (targetOffset < 0) return;
+	function getNodePath(root: Node, node: Node): number[] | null {
+		const path: number[] = [];
+		let cur: Node = node;
+		while (cur !== root) {
+			const parent = cur.parentNode;
+			if (!parent) return null;
+			const idx = Array.from(parent.childNodes).indexOf(cur as ChildNode);
+			if (idx === -1) return null;
+			path.unshift(idx);
+			cur = parent;
+		}
+		return path;
+	}
+
+	function resolveNodePath(root: Node, path: number[]): Node | null {
+		let cur: Node = root;
+		for (const idx of path) {
+			const child = cur.childNodes[idx];
+			if (!child) return null;
+			cur = child;
+		}
+		return cur;
+	}
+
+	function saveCursorPosition(root: HTMLElement): CursorPos | null {
+		const sel = window.getSelection();
+		if (!sel || sel.rangeCount === 0) return null;
+		const range = sel.getRangeAt(0);
+		if (!root.contains(range.startContainer)) return null;
+
+		const path = getNodePath(root, range.startContainer);
+		if (!path) return null;
+		return { path, offset: range.startOffset, isCollapsed: range.collapsed };
+	}
+
+	function restoreCursorPosition(root: HTMLElement, pos: CursorPos): void {
 		const sel = window.getSelection();
 		if (!sel) return;
-		const iter = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
-		let offset = 0;
-		let node: Node | null;
-		while ((node = iter.nextNode())) {
-			const len = (node as Text).length;
-			if (offset + len >= targetOffset) {
-				const range = document.createRange();
-				range.setStart(node, Math.min(targetOffset - offset, len));
-				range.collapse(true);
-				sel.removeAllRanges();
-				sel.addRange(range);
-				return;
-			}
-			offset += len;
+		const node = resolveNodePath(root, pos.path);
+		if (!node) {
+			// Path no longer valid (content changed) — put cursor at end
+			const range = document.createRange();
+			range.selectNodeContents(root);
+			range.collapse(false);
+			sel.removeAllRanges();
+			sel.addRange(range);
+			return;
 		}
-		// targetOffset past end of content — put cursor at end
+		const maxOffset = node.nodeType === Node.TEXT_NODE
+			? (node as Text).length
+			: node.childNodes.length;
+		const clampedOffset = Math.min(pos.offset, maxOffset);
 		const range = document.createRange();
-		range.selectNodeContents(root);
-		range.collapse(false);
+		range.setStart(node, clampedOffset);
+		range.collapse(true);
 		sel.removeAllRanges();
 		sel.addRange(range);
 	}
@@ -204,25 +243,22 @@
 	/** Apply an external update to the editor, preserving cursor position. */
 	function applyExternalUpdate(update: ExternalUpdate): void {
 		if (!bodyEl) return;
-		// Check if cursor is inside the editor
 		const sel = window.getSelection();
 		const editorFocused = sel && sel.rangeCount > 0 && bodyEl.contains(sel.getRangeAt(0).startContainer);
-
-		const charOffset = editorFocused ? getCharOffset(bodyEl) : -1;
-		const prevLen = bodyEl.innerText.length;
+		const cursorPos = editorFocused ? saveCursorPosition(bodyEl) : null;
 
 		title = update.title;
 		bodyEl.innerHTML = update.body;
 
-		if (editorFocused && charOffset >= 0) {
-			const newLen = bodyEl.innerText.length;
-			// If content shrank and cursor was beyond new end, clamp to new end
-			const restoredOffset = newLen < prevLen && charOffset > newLen ? newLen : charOffset;
-			setCharOffset(bodyEl, restoredOffset);
+		if (cursorPos) {
+			restoreCursorPosition(bodyEl, cursorPos);
 		}
 	}
 
 	let incomingUpdate = $state<ExternalUpdate | null>(null);
+	// Timestamp of the last time we saved — suppress external updates that arrive
+	// within a short window after our own save to avoid false conflict banners.
+	let _lastSaveAt = 0;
 
 	$effect(() => {
 		if (isNew || !noteId) return;
@@ -230,11 +266,13 @@
 		if (!update) return;
 		externalUpdates.delete(noteId); // consume
 
+		// Suppress updates that arrive <3 s after we saved the same note ourselves.
+		// These are echoes of our own write propagated back via the sync channel.
+		if (Date.now() - _lastSaveAt < 3000) return;
+
 		if (saved) {
-			// Editor is clean — apply silently without disturbing the user
 			applyExternalUpdate(update);
 		} else {
-			// User has unsaved changes — show banner, let them decide
 			incomingUpdate = update;
 		}
 	});
@@ -273,17 +311,25 @@
 	// ── Rich text commands ────────────────────────────────────────
 	// PLACEHOLDER: uses document.execCommand (deprecated). Phase 6: ProseMirror.
 
-	// Saved selection range from the last editor focus — restored before execCommand
-	// so toolbar button clicks don't lose the cursor position.
+	// ── Toolbar selection preservation ───────────────────────────
+	// When a toolbar button is clicked, the editor loses focus (blur) before the
+	// click handler runs.  We save the Range on blur and restore it inside exec()
+	// BEFORE focus() is called — this prevents the browser from resetting the
+	// selection to the start of the editable div.
+	//
+	// IMPORTANT: Do NOT clear _savedRange on focus.  The sequence for a toolbar
+	// click is: editor blur → save range → button mousedown → button click fires
+	// exec() → exec calls focus() → editor focus → exec calls restoreSavedRange()
+	// If we cleared on focus, the range would be gone before restoreSavedRange().
+
 	let _savedRange: Range | null = null;
 
 	function onEditorFocus() {
-		// Clear stale saved range when editor gains focus so we always track current
-		_savedRange = null;
+		// Do NOT clear _savedRange here — see comment above.
+		// The range is cleared in restoreSavedRange() after it is used.
 	}
 
 	function onEditorBlur() {
-		// Save the selection range when editor loses focus (e.g. toolbar button click)
 		const sel = window.getSelection();
 		if (sel && sel.rangeCount > 0 && bodyEl?.contains(sel.getRangeAt(0).commonAncestorContainer)) {
 			_savedRange = sel.getRangeAt(0).cloneRange();
@@ -292,40 +338,38 @@
 
 	function restoreSavedRange() {
 		if (!_savedRange) return;
+		const range = _savedRange;
+		_savedRange = null; // consume — clear after use, not on focus
 		const sel = window.getSelection();
 		if (sel) {
 			sel.removeAllRanges();
-			sel.addRange(_savedRange);
+			sel.addRange(range);
 		}
 	}
 
 	function exec(cmd: string, value?: string) {
+		// Restore saved range BEFORE focus so the browser sees the right selection
+		// when focus() triggers internal selection restoration.
+		if (_savedRange) restoreSavedRange();
 		bodyEl?.focus();
-		restoreSavedRange(); // restore cursor after focus (toolbar click blurs editor)
 		document.execCommand(cmd, false, value);
-		// Update state immediately after command (not waiting for keyup/mouseup)
 		updateFormatState();
 		saved = false;
 		scheduleAutosave();
 	}
 
-	// Font size: map label → px value stored in a data attribute on the select.
-	// We toggle individual size spans around the selection rather than using the
-	// unreliable execCommand fontSize workaround.
 	function execFontSize(px: string) {
+		if (_savedRange) restoreSavedRange();
 		bodyEl?.focus();
-		restoreSavedRange();
-		// Step 1: remove any existing font-size span inside the selection
-		// Step 2: wrap selection in <span style="font-size:Xpx">
+		// Use the font-size=7 marker trick to find the selected range, then
+		// replace with a proper <span style="font-size:Xpx">.
 		document.execCommand('fontSize', false, '7');
-		const markers = bodyEl.querySelectorAll('font[size="7"]');
-		markers.forEach((el) => {
+		bodyEl?.querySelectorAll('font[size="7"]').forEach((el) => {
 			const span = document.createElement('span');
 			span.style.fontSize = px;
 			span.innerHTML = (el as HTMLElement).innerHTML;
 			el.replaceWith(span);
 		});
-		bodyEl.focus();
 		updateFormatState();
 		saved = false;
 		scheduleAutosave();
@@ -338,8 +382,9 @@
 	let isStrike    = $state(false);
 	let isUL        = $state(false);
 	let isOL        = $state(false);
-	// Current font size label detected from selection (empty string = mixed/unknown)
+	// Current font size in px detected from selection ('15' = 15px default)
 	let currentFontSize = $state('');
+	let showFontSizePicker = $state(false);
 
 	function updateFormatState() {
 		if (typeof document === 'undefined') return;
@@ -349,34 +394,27 @@
 		isStrike    = document.queryCommandState('strikeThrough');
 		isUL        = document.queryCommandState('insertUnorderedList');
 		isOL        = document.queryCommandState('insertOrderedList');
-		// Detect font size from the focused node's computed style
-		currentFontSize = detectFontSize();
+		currentFontSize = detectFontSizePx();
 	}
 
-	function detectFontSize(): string {
+	// Walk up from the selection to find the nearest explicit font-size style.
+	// Returns the numeric px value as a string (e.g. '12'), or '' if none found.
+	function detectFontSizePx(): string {
 		const sel = window.getSelection();
 		if (!sel || sel.rangeCount === 0) return '';
-		let node: Node | null = sel.getRangeAt(0).commonAncestorContainer;
-		// Walk up to find a span with an explicit font-size style
+		let node: Node | null = sel.getRangeAt(0).startContainer;
+		if (node?.nodeType === Node.TEXT_NODE) node = node.parentNode;
 		while (node && node !== bodyEl) {
 			if (node.nodeType === Node.ELEMENT_NODE) {
 				const fs = (node as HTMLElement).style.fontSize;
-				if (fs) {
-					const match = fontSizes.find(s => s.value === fs);
-					return match ? match.value : '';
-				}
+				if (fs && fs.endsWith('px')) return fs.slice(0, -2);
 			}
-			node = node.parentNode;
+			node = (node as Element).parentElement;
 		}
 		return '';
 	}
 
-	const fontSizes = [
-		{ label: 'Small',   value: '12px' },
-		{ label: 'Normal',  value: '15px' },
-		{ label: 'Large',   value: '20px' },
-		{ label: 'Heading', value: '26px' },
-	];
+	const fontSizeOptions = [8, 10, 12, 14, 16, 18, 20, 24, 28, 32, 36, 48, 72];
 
 	// Color swatches
 	const textColors = [
@@ -392,10 +430,65 @@
 
 	let showColorPicker = $state(false);
 	let customColor = $state('#e2e4ed');
+	let colorBtnEl = $state<HTMLButtonElement | undefined>(undefined);
+	let colorPanelEl = $state<HTMLDivElement | undefined>(undefined);
+	let fontsizeBtnEl = $state<HTMLButtonElement | undefined>(undefined);
+	let fontsizePanelEl = $state<HTMLDivElement | undefined>(undefined);
+
+	// Position a floating panel below its trigger button.
+	function positionPanel(btn: HTMLElement | undefined, panel: HTMLElement | undefined) {
+		if (!btn || !panel) return;
+		const rect = btn.getBoundingClientRect();
+		panel.style.top  = (rect.bottom + 6) + 'px';
+		panel.style.left = rect.left + 'px';
+		// Clamp so it doesn't go off-screen to the right
+		requestAnimationFrame(() => {
+			const pr = panel.getBoundingClientRect();
+			if (pr.right > window.innerWidth - 8) {
+				panel.style.left = Math.max(8, window.innerWidth - pr.width - 8) + 'px';
+			}
+		});
+	}
+
+	$effect(() => {
+		if (showColorPicker) positionPanel(colorBtnEl, colorPanelEl);
+	});
+	$effect(() => {
+		if (showFontSizePicker) positionPanel(fontsizeBtnEl, fontsizePanelEl);
+	});
 
 	function applyColor(color: string) {
+		customColor = color;
 		exec('foreColor', color);
 		showColorPicker = false;
+	}
+
+	// ── Clear formatting ─────────────────────────────────────────
+	function clearFormatting() {
+		exec('removeFormat');
+		// removeFormat doesn't remove lists — toggle them off if active
+		if (document.queryCommandState('insertUnorderedList')) exec('insertUnorderedList');
+		if (document.queryCommandState('insertOrderedList')) exec('insertOrderedList');
+	}
+
+	// ── Paste without formatting (Ctrl+Shift+V) ──────────────────
+	function handlePaste(e: ClipboardEvent) {
+		// Ctrl+Shift+V → paste as plain text in the current cursor style
+		const isPlainPaste = e.shiftKey && (e.ctrlKey || e.metaKey);
+		// Also strip formatting from any paste that contains styled HTML (standard Ctrl+V)
+		// so pasted content doesn't override the user's formatting for subsequent typing.
+		const html = e.clipboardData?.getData('text/html') ?? '';
+		const text = e.clipboardData?.getData('text/plain') ?? '';
+
+		if (isPlainPaste || html) {
+			e.preventDefault();
+			// Insert plain text at cursor — preserves current typing style
+			const plain = text || (e.clipboardData?.getData('text/plain') ?? '');
+			document.execCommand('insertText', false, plain);
+			saved = false;
+			scheduleAutosave();
+		}
+		// Else: let the browser handle it (e.g. images)
 	}
 
 	// ── Delete confirm ────────────────────────────────────────────
@@ -544,7 +637,7 @@
 				<rect x="3" y="6" width="8" height="7" rx="1.2" stroke="currentColor" stroke-width="1.3"/>
 				<path d="M5 6V4.5a2 2 0 114 0V6" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
 			</svg>
-			<span>Vault locked — edits saved locally but not synced to server until you unlock.</span>
+			<span>Vault locked — viewing only. Unlock in the main window to edit and sync.</span>
 		</div>
 	{/if}
 
@@ -758,22 +851,46 @@
 
 		<div class="fmt-divider"></div>
 
-		<!-- Font size — value reflects current selection; selecting applies it -->
-		<select
-			class="fmt-select"
-			title="Font size"
-			aria-label="Font size"
-			value={currentFontSize}
-			onchange={(e) => {
-				const v = (e.target as HTMLSelectElement).value;
-				if (v) execFontSize(v);
-			}}
-		>
-			<option value="" disabled>Size</option>
-			{#each fontSizes as fs}
-				<option value={fs.value}>{fs.label}</option>
-			{/each}
-		</select>
+		<!-- Font size — custom pixel picker -->
+		<div class="fontsize-wrap">
+			<button
+				class="fmt-btn fontsize-btn"
+				bind:this={fontsizeBtnEl}
+				onmousedown={(e) => {
+					e.preventDefault(); // keep editor focus
+					showFontSizePicker = !showFontSizePicker;
+					showColorPicker = false;
+				}}
+				title="Font size"
+				aria-label="Font size"
+				aria-expanded={showFontSizePicker}
+			>
+				<span class="fontsize-label">{currentFontSize ? currentFontSize + 'px' : 'Size'}</span>
+				<svg width="8" height="5" viewBox="0 0 8 5" fill="none" aria-hidden="true">
+					<path d="M1 1l3 3 3-3" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+				</svg>
+			</button>
+
+			{#if showFontSizePicker}
+				<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+				<div class="fontsize-backdrop" onclick={() => (showFontSizePicker = false)}></div>
+				<div class="fontsize-panel" bind:this={fontsizePanelEl} role="listbox" aria-label="Font size options">
+					{#each fontSizeOptions as sz}
+						<button
+							class="fontsize-option"
+							class:active={currentFontSize === String(sz)}
+							role="option"
+							aria-selected={currentFontSize === String(sz)}
+							onmousedown={(e) => {
+								e.preventDefault();
+								execFontSize(sz + 'px');
+								showFontSizePicker = false;
+							}}
+						>{sz}</button>
+					{/each}
+				</div>
+			{/if}
+		</div>
 
 		<div class="fmt-divider"></div>
 
@@ -781,7 +898,12 @@
 		<div class="color-wrap">
 			<button
 				class="fmt-btn color-btn"
-				onclick={() => (showColorPicker = !showColorPicker)}
+				bind:this={colorBtnEl}
+				onmousedown={(e) => {
+					e.preventDefault();
+					showColorPicker = !showColorPicker;
+					showFontSizePicker = false;
+				}}
 				title="Text color"
 				aria-label="Text color"
 				aria-expanded={showColorPicker}
@@ -796,25 +918,35 @@
 			{#if showColorPicker}
 				<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
 				<div class="color-backdrop" onclick={() => (showColorPicker = false)}></div>
-				<div class="color-panel" role="dialog" aria-label="Text color picker">
+				<div class="color-panel" bind:this={colorPanelEl} role="dialog" aria-label="Text color picker">
 					<div class="color-swatches">
 						{#each textColors as c}
 							<button
 								class="color-swatch"
 								style="background: {c}"
-								onclick={() => { customColor = c; applyColor(c); }}
+								onmousedown={(e) => { e.preventDefault(); applyColor(c); }}
 								aria-label="Color {c}"
 							></button>
 						{/each}
 					</div>
 					<div class="color-custom-row">
 						<input type="color" class="color-input-native" bind:value={customColor}
-							oninput={() => applyColor(customColor)} title="Custom color" />
+							onchange={() => applyColor(customColor)} title="Custom color" />
 						<span class="color-custom-label">Custom</span>
 					</div>
 				</div>
 			{/if}
 		</div>
+
+		<div class="fmt-divider"></div>
+
+		<!-- Clear formatting -->
+		<button class="fmt-btn" onmousedown={(e) => { e.preventDefault(); clearFormatting(); }} title="Clear formatting" aria-label="Clear formatting">
+			<svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+				<path d="M2 3h10M4.5 3l1 8M9.5 3l-1 8M6 7h2" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+				<path d="M10 11l3 3M13 11l-3 3" stroke="var(--danger)" stroke-width="1.3" stroke-linecap="round"/>
+			</svg>
+		</button>
 	</div>
 
 	<!-- ── Editable body ────────────────────────────────────────── -->
@@ -829,6 +961,7 @@
 		onselectionchange={updateFormatState}
 		onfocus={onEditorFocus}
 		onblur={onEditorBlur}
+		onpaste={handlePaste}
 		data-placeholder="Start writing…"
 		spellcheck="true"
 		role="textbox"
@@ -1518,33 +1651,63 @@
 		flex-shrink: 0;
 	}
 
-	/* Font size select — shows current selection label; placeholder "Size" when mixed */
-	.fmt-select {
-		font-size: 11px;
-		padding: 5px 6px;
-		width: auto;
-		min-width: 62px;
-		background: var(--bg-hover);
+	/* Font size custom picker */
+	.fontsize-wrap { position: relative; flex-shrink: 0; }
+
+	.fontsize-btn {
+		gap: 4px;
+		min-width: 52px;
+		justify-content: space-between;
+		padding: 5px 8px;
 		border: 1px solid var(--border);
+		background: var(--bg-hover);
 		border-radius: var(--radius-sm);
 		color: var(--text-muted);
+	}
+
+	.fontsize-label {
+		font-size: 12px;
+		font-weight: 500;
+		line-height: 1;
+		white-space: nowrap;
+	}
+
+	.fontsize-backdrop { position: fixed; inset: 0; z-index: 200; }
+
+	.fontsize-panel {
+		position: fixed;
+		z-index: 201;
+		background: var(--bg-elevated);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-md);
+		padding: 4px 0;
+		display: flex;
+		flex-direction: column;
+		box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+		max-height: 260px;
+		overflow-y: auto;
+		min-width: 70px;
+	}
+
+	.fontsize-option {
+		padding: 6px 14px;
+		text-align: left;
+		font-size: 13px;
+		color: var(--text-muted);
+		background: none;
+		border: none;
 		cursor: pointer;
-		flex-shrink: 0;
-		/* Prevent iOS auto-zoom on the select element */
-		font-size: 16px;
+		transition: background 0.1s, color 0.1s;
+		white-space: nowrap;
 	}
 
-	/* Scale down visually while keeping font-size ≥ 16px for iOS */
-	.fmt-select {
-		transform-origin: left center;
-		font-size: 16px;
+	.fontsize-option:hover,
+	.fontsize-option.active {
+		background: var(--bg-hover);
+		color: var(--text);
 	}
 
-	@media (min-width: 768px) {
-		.fmt-select { font-size: 12px; }
-	}
-
-	.fmt-select:focus { box-shadow: none; border-color: var(--accent); }
+	.fontsize-option.active { color: var(--accent); }
 
 	/* Color picker */
 	.color-wrap { position: relative; flex-shrink: 0; }
@@ -1558,13 +1721,11 @@
 		display: inline-block;
 	}
 
-	.color-backdrop { position: fixed; inset: 0; z-index: 50; }
+	.color-backdrop { position: fixed; inset: 0; z-index: 200; }
 
 	.color-panel {
-		position: absolute;
-		top: calc(100% + 6px);
-		left: 0;
-		z-index: 51;
+		position: fixed;
+		z-index: 201;
 		background: var(--bg-elevated);
 		border: 1px solid var(--border);
 		border-radius: var(--radius-md);

--- a/bedroc/src/routes/settings/+page.svelte
+++ b/bedroc/src/routes/settings/+page.svelte
@@ -11,19 +11,23 @@
 	interface Session {
 		id: string;
 		device_info: string | null;
+		login_ip: string | null;
+		last_used_at: string | null;
 		created_at: string;
 		expires_at: string;
 	}
 
 	let sessions = $state<Session[]>([]);
+	let currentSessionId = $state<string | null>(null);
 	let sessionsLoading = $state(true);
 
 	async function loadSessions() {
 		try {
 			const res = await apiFetch('/api/auth/sessions');
 			if (res.ok) {
-				const data = await res.json() as { sessions: Session[] };
+				const data = await res.json() as { sessions: Session[]; currentSessionId: string | null };
 				sessions = data.sessions ?? [];
+				currentSessionId = data.currentSessionId ?? null;
 			}
 		} catch { /* offline */ }
 		sessionsLoading = false;
@@ -388,18 +392,33 @@
 			{:else}
 				{#each sessions as session, i (session.id)}
 					{#if i > 0}<div class="divider-inner"></div>{/if}
-					<div class="row">
+					<div class="row session-row">
 						<div class="row-info">
-							<span class="row-label">
+							<span class="row-label session-label">
 								{session.device_info ?? 'Unknown device'}
+								{#if session.id === currentSessionId}
+									<span class="session-current-badge">This device</span>
+								{/if}
 							</span>
 							<span class="row-sub">
-								Active until {new Date(session.expires_at).toLocaleDateString()}
+								Logged in {session.last_used_at
+									? new Date(session.last_used_at).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+									: new Date(session.created_at).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })}
+								{#if session.login_ip}
+									· {session.login_ip}
+								{/if}
+							</span>
+							<span class="row-sub session-expiry">
+								Expires {new Date(session.expires_at).toLocaleDateString()}
 							</span>
 						</div>
-						<button class="btn-ghost revoke-btn" onclick={() => revokeSession(session.id)}>
-							Revoke
-						</button>
+						{#if session.id !== currentSessionId}
+							<button class="btn-ghost revoke-btn" onclick={() => revokeSession(session.id)}>
+								Revoke
+							</button>
+						{:else}
+							<span class="session-current-label">Current</span>
+						{/if}
 					</div>
 				{/each}
 			{/if}
@@ -588,6 +607,38 @@
 		color: var(--accent);
 		padding: 2px 6px;
 		border-radius: 999px;
+	}
+
+	/* Session row */
+	.session-label {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		flex-wrap: wrap;
+	}
+
+	.session-current-badge {
+		font-size: 10px;
+		font-weight: 600;
+		color: var(--accent);
+		background: color-mix(in srgb, var(--accent) 14%, transparent);
+		border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+		border-radius: 999px;
+		padding: 1px 7px;
+		letter-spacing: 0.02em;
+		flex-shrink: 0;
+	}
+
+	.session-expiry {
+		color: var(--text-faint);
+		font-size: 11px;
+	}
+
+	.session-current-label {
+		font-size: 12px;
+		color: var(--text-faint);
+		flex-shrink: 0;
+		padding: 5px 10px;
 	}
 
 	/* Revoke / danger buttons */

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -56,7 +56,7 @@ export async function runMigrations(): Promise<void> {
   const migrationClient = new pg.Client({ connectionString: migrationUrl });
   await migrationClient.connect();
 
-  const migrations = ['001_init.sql', '002_session_refresh_hash.sql'];
+  const migrations = ['001_init.sql', '002_session_refresh_hash.sql', '003_session_metadata.sql'];
   try {
     for (const file of migrations) {
       const sqlPath = join(__dir, 'migrations', file);

--- a/server/src/db/migrations/003_session_metadata.sql
+++ b/server/src/db/migrations/003_session_metadata.sql
@@ -1,0 +1,12 @@
+-- =============================================================================
+-- Migration 003: Add login_ip and last_used_at to sessions
+--
+-- login_ip       — IP address recorded at login time (NULL for old sessions)
+-- last_used_at   — Timestamp of the most recent activity on this session
+--
+-- Both columns are optional/nullable so existing sessions are not broken.
+-- =============================================================================
+
+ALTER TABLE sessions
+    ADD COLUMN IF NOT EXISTS login_ip TEXT,
+    ADD COLUMN IF NOT EXISTS last_used_at TIMESTAMPTZ;

--- a/server/src/db/queries/users.ts
+++ b/server/src/db/queries/users.ts
@@ -27,6 +27,8 @@ export interface SessionRow {
   token_hash: string;
   refresh_token_hash: string | null;
   device_info: string | null;
+  login_ip: string | null;
+  last_used_at: Date | null;
   created_at: Date;
   expires_at: Date;
   revoked: boolean;
@@ -96,13 +98,14 @@ export async function createSession(params: {
   tokenHash: string;
   refreshTokenHash: string;
   deviceInfo: string | null;
+  loginIp: string | null;
   expiresAt: Date;
 }): Promise<SessionRow> {
   const { rows } = await query<SessionRow>(
-    `INSERT INTO sessions (user_id, token_hash, refresh_token_hash, device_info, expires_at)
-     VALUES ($1, $2, $3, $4, $5)
+    `INSERT INTO sessions (user_id, token_hash, refresh_token_hash, device_info, login_ip, last_used_at, expires_at)
+     VALUES ($1, $2, $3, $4, $5, now(), $6)
      RETURNING *`,
-    [params.userId, params.tokenHash, params.refreshTokenHash, params.deviceInfo, params.expiresAt]
+    [params.userId, params.tokenHash, params.refreshTokenHash, params.deviceInfo, params.loginIp, params.expiresAt]
   );
   return rows[0];
 }
@@ -118,6 +121,7 @@ export async function upsertSessionForDevice(params: {
   tokenHash: string;
   refreshTokenHash: string;
   deviceInfo: string | null;
+  loginIp: string | null;
   expiresAt: Date;
 }): Promise<SessionRow> {
   // First, prune expired/revoked sessions for this user
@@ -128,10 +132,10 @@ export async function upsertSessionForDevice(params: {
     const { rowCount, rows } = await query<SessionRow>(
       `UPDATE sessions
        SET token_hash = $3, refresh_token_hash = $4, expires_at = $5,
-           revoked = false, created_at = now()
+           revoked = false, created_at = now(), last_used_at = now(), login_ip = $6
        WHERE user_id = $1 AND device_info = $2 AND revoked = false
        RETURNING *`,
-      [params.userId, params.deviceInfo, params.tokenHash, params.refreshTokenHash, params.expiresAt]
+      [params.userId, params.deviceInfo, params.tokenHash, params.refreshTokenHash, params.expiresAt, params.loginIp]
     );
     if ((rowCount ?? 0) > 0) return rows[0];
   }
@@ -152,7 +156,7 @@ export async function refreshSession(params: {
 }): Promise<boolean> {
   const { rowCount } = await query(
     `UPDATE sessions
-     SET token_hash = $2, refresh_token_hash = $3, expires_at = $4
+     SET token_hash = $2, refresh_token_hash = $3, expires_at = $4, last_used_at = now()
      WHERE refresh_token_hash = $1
        AND revoked = false
        AND expires_at > now()`,
@@ -182,12 +186,12 @@ export async function revokeAllSessions(userId: string): Promise<void> {
 
 export async function getSessionsForUser(userId: string): Promise<SessionRow[]> {
   const { rows } = await query<SessionRow>(
-    `SELECT id, user_id, device_info, created_at, expires_at, revoked
+    `SELECT id, user_id, device_info, login_ip, last_used_at, created_at, expires_at, revoked
      FROM sessions
      WHERE user_id = $1
        AND revoked = false
        AND expires_at > now()
-     ORDER BY created_at DESC
+     ORDER BY last_used_at DESC NULLS LAST, created_at DESC
      LIMIT 20`,
     [userId]
   );

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -133,10 +133,15 @@ await app.register(fastifyCors, {
 // ---------------------------------------------------------------------------
 // Rate limiting
 // ---------------------------------------------------------------------------
-// Global 200 req/min limit; auth routes apply stricter limits themselves.
+// Global 500 req/min per-IP fallback. Individual route overrides below.
+// With 0.5 s minimum sync interval, sync alone can reach 120 req/min.
+// Notes/topics/folders CRUD during rapid reordering adds another ~100/min.
+// Auth routes keep their own much stricter per-route limits (see auth.ts).
+// To change per-route limits, set config.rateLimit on the route handler.
+// To change the global fallback, update the max value below.
 await app.register(fastifyRateLimit, {
   global: true,
-  max: 250,
+  max: 500,
   timeWindow: '1 minute',
   // Use real IP from X-Forwarded-For (nginx sets this)
   keyGenerator: (req) => req.ip,

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -32,7 +32,7 @@ import {
   createUser, getUserByUsername, getUserById,
   upsertSessionForDevice, refreshSession, revokeSession, revokeAllSessions,
   getSessionsForUser, revokeSessionById, updateUserCredentials,
-  pruneExpiredSessions,
+  pruneExpiredSessions, getSessionByHash,
 } from '../db/queries/users.js';
 import { hashToken, verifyAuth } from '../middleware/auth.js';
 import { getRedis } from '../plugins/redis.js';
@@ -197,6 +197,20 @@ function verifySrpProof(params: {
 // ---------------------------------------------------------------------------
 
 /**
+ * Extract the best-effort client IP from the request.
+ * nginx sets X-Forwarded-For when proxying; use the first entry (original client).
+ * Falls back to req.ip (direct connection).
+ */
+function getClientIp(req: FastifyRequest): string | null {
+  const forwarded = req.headers['x-forwarded-for'];
+  if (forwarded) {
+    const first = (Array.isArray(forwarded) ? forwarded[0] : forwarded).split(',')[0].trim();
+    return first || null;
+  }
+  return req.ip || null;
+}
+
+/**
  * Derive a short human-readable device label from a User-Agent string.
  * Returns something like "Chrome on Windows", "Safari on iPhone", "Firefox on Mac".
  * Avoids storing the full raw UA string in the sessions list.
@@ -204,24 +218,30 @@ function verifySrpProof(params: {
 function parseDeviceInfo(ua: string): string {
   if (!ua) return 'Unknown device';
 
-  // OS / platform detection
+  // OS detection — order matters: check mobile/specific before generic desktop
   let os = 'Unknown OS';
   if (/iPhone/.test(ua))                    os = 'iPhone';
   else if (/iPad/.test(ua))                 os = 'iPad';
   else if (/Android/.test(ua))              os = 'Android';
   else if (/Windows NT/.test(ua))           os = 'Windows';
+  else if (/CrOS/.test(ua))                 os = 'ChromeOS';
   else if (/Macintosh|Mac OS X/.test(ua))   os = 'Mac';
   else if (/Linux/.test(ua))                os = 'Linux';
-  else if (/CrOS/.test(ua))                 os = 'ChromeOS';
 
-  // Browser detection (order matters — check specific ones before generic)
+  // Browser detection — order matters: check specific products first
+  // Edg/  = Edge on desktop (Windows/Mac)
+  // EdgA/ = Edge on Android/iOS (mobile)
   let browser = 'Unknown browser';
-  if (/Edg\//.test(ua))                     browser = 'Edge';
-  else if (/OPR\/|Opera/.test(ua))          browser = 'Opera';
+  if (/Electron\//.test(ua))                browser = 'Electron app';
+  else if (/EdgA\//.test(ua))               browser = 'Edge';
+  else if (/Edg\//.test(ua))                browser = 'Edge';
+  else if (/OPR\/|OPiOS\/|Opera/.test(ua))  browser = 'Opera';
   else if (/SamsungBrowser/.test(ua))       browser = 'Samsung Browser';
+  else if (/CriOS\//.test(ua))              browser = 'Chrome';   // Chrome on iOS
+  else if (/FxiOS\//.test(ua))              browser = 'Firefox';  // Firefox on iOS
   else if (/Chrome\//.test(ua))             browser = 'Chrome';
   else if (/Firefox\//.test(ua))            browser = 'Firefox';
-  else if (/Safari\//.test(ua) && /Version\//.test(ua)) browser = 'Safari';
+  else if (/Version\//.test(ua) && /Safari\//.test(ua)) browser = 'Safari';
   else if (/Safari\//.test(ua))             browser = 'Safari';
 
   return `${browser} on ${os}`;
@@ -270,6 +290,12 @@ function issueTokens(
     refreshExpiresAt: new Date(Date.now() + refreshMs),
     refreshMaxAge:    Math.floor(refreshMs / 1000), // seconds for cookie maxAge
   };
+}
+
+/** Return the session ID for the given raw access token, or null if not found. */
+async function getCurrentSessionId(accessToken: string): Promise<string | null> {
+  const session = await getSessionByHash(hashToken(accessToken));
+  return session?.id ?? null;
 }
 
 // ---------------------------------------------------------------------------
@@ -328,6 +354,7 @@ export default async function authRoutes(fastify: FastifyInstance): Promise<void
       tokenHash:        hashToken(accessToken),
       refreshTokenHash: hashToken(refreshToken),
       deviceInfo:       deviceInfo || null,
+      loginIp:          getClientIp(req),
       expiresAt:        refreshExpiresAt,
     });
 
@@ -433,6 +460,7 @@ export default async function authRoutes(fastify: FastifyInstance): Promise<void
       tokenHash:        hashToken(accessToken),
       refreshTokenHash: hashToken(refreshToken),
       deviceInfo:       deviceInfo || null,
+      loginIp:          getClientIp(req),
       expiresAt:        refreshExpiresAt,
     });
 
@@ -498,6 +526,7 @@ export default async function authRoutes(fastify: FastifyInstance): Promise<void
         tokenHash:        hashToken(accessToken),
         refreshTokenHash: hashToken(newRefresh),
         deviceInfo:       deviceInfo || null,
+        loginIp:          getClientIp(req),
         expiresAt:        refreshExpiresAt,
       });
     } else {
@@ -537,7 +566,13 @@ export default async function authRoutes(fastify: FastifyInstance): Promise<void
     if (reply.sent) return;
     const userId = (req as FastifyRequest & { userId: string }).userId;
     const sessions = await getSessionsForUser(userId);
-    return reply.code(200).send({ sessions });
+
+    // Identify the current session by matching the access token hash
+    const authHeader = req.headers.authorization ?? '';
+    const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null;
+    const currentSessionId = token ? await getCurrentSessionId(token) : null;
+
+    return reply.code(200).send({ sessions, currentSessionId });
   });
 
   // ── Revoke a specific session (protected) ───────────────────────────────

--- a/server/src/routes/notes.ts
+++ b/server/src/routes/notes.ts
@@ -64,7 +64,9 @@ function uid(req: FastifyRequest): string {
 export default async function notesRoutes(fastify: FastifyInstance): Promise<void> {
 
   // ── GET /api/notes — list all notes for the authenticated user ───────────
-  fastify.get('/api/notes', async (req: FastifyRequest, reply: FastifyReply) => {
+  fastify.get('/api/notes', {
+    config: { rateLimit: { max: 120, timeWindow: '1 minute' } },
+  }, async (req: FastifyRequest, reply: FastifyReply) => {
     await verifyAuth(req, reply);
     if (reply.sent) return;
     const notes = await getNotesByUser(uid(req));
@@ -72,7 +74,10 @@ export default async function notesRoutes(fastify: FastifyInstance): Promise<voi
   });
 
   // ── GET /api/notes/sync?since=ISO — delta sync ───────────────────────────
-  fastify.get('/api/notes/sync', async (req: FastifyRequest, reply: FastifyReply) => {
+  // High limit: 0.5 s minimum sync interval = up to 120 req/min just from sync.
+  fastify.get('/api/notes/sync', {
+    config: { rateLimit: { max: 200, timeWindow: '1 minute' } },
+  }, async (req: FastifyRequest, reply: FastifyReply) => {
     await verifyAuth(req, reply);
     if (reply.sent) return;
     const { since } = req.query as { since?: string };
@@ -83,7 +88,9 @@ export default async function notesRoutes(fastify: FastifyInstance): Promise<voi
   });
 
   // ── GET /api/notes/:id — fetch a single note ─────────────────────────────
-  fastify.get('/api/notes/:id', async (req: FastifyRequest, reply: FastifyReply) => {
+  fastify.get('/api/notes/:id', {
+    config: { rateLimit: { max: 120, timeWindow: '1 minute' } },
+  }, async (req: FastifyRequest, reply: FastifyReply) => {
     await verifyAuth(req, reply);
     if (reply.sent) return;
     const { id } = req.params as { id: string };
@@ -93,7 +100,10 @@ export default async function notesRoutes(fastify: FastifyInstance): Promise<voi
   });
 
   // ── PUT /api/notes/:id — upsert (create or update) ───────────────────────
-  fastify.put('/api/notes/:id', async (req: FastifyRequest, reply: FastifyReply) => {
+  // High limit: rapid typing with short autosave + instant sync intervals.
+  fastify.put('/api/notes/:id', {
+    config: { rateLimit: { max: 200, timeWindow: '1 minute' } },
+  }, async (req: FastifyRequest, reply: FastifyReply) => {
     await verifyAuth(req, reply);
     if (reply.sent) return;
     const { id } = req.params as { id: string };
@@ -117,7 +127,9 @@ export default async function notesRoutes(fastify: FastifyInstance): Promise<voi
   });
 
   // ── DELETE /api/notes/:id — soft delete ──────────────────────────────────
-  fastify.delete('/api/notes/:id', async (req: FastifyRequest, reply: FastifyReply) => {
+  fastify.delete('/api/notes/:id', {
+    config: { rateLimit: { max: 60, timeWindow: '1 minute' } },
+  }, async (req: FastifyRequest, reply: FastifyReply) => {
     await verifyAuth(req, reply);
     if (reply.sent) return;
     const { id } = req.params as { id: string };
@@ -127,7 +139,9 @@ export default async function notesRoutes(fastify: FastifyInstance): Promise<voi
   });
 
   // ── GET /api/topics ───────────────────────────────────────────────────────
-  fastify.get('/api/topics', async (req: FastifyRequest, reply: FastifyReply) => {
+  fastify.get('/api/topics', {
+    config: { rateLimit: { max: 120, timeWindow: '1 minute' } },
+  }, async (req: FastifyRequest, reply: FastifyReply) => {
     await verifyAuth(req, reply);
     if (reply.sent) return;
     const topics = await getTopicsByUser(uid(req));
@@ -135,7 +149,10 @@ export default async function notesRoutes(fastify: FastifyInstance): Promise<voi
   });
 
   // ── PUT /api/topics/:id ───────────────────────────────────────────────────
-  fastify.put('/api/topics/:id', async (req: FastifyRequest, reply: FastifyReply) => {
+  // Higher limit for rapid reordering: dragging multiple topics fires many PUT calls.
+  fastify.put('/api/topics/:id', {
+    config: { rateLimit: { max: 120, timeWindow: '1 minute' } },
+  }, async (req: FastifyRequest, reply: FastifyReply) => {
     await verifyAuth(req, reply);
     if (reply.sent) return;
     const { id } = req.params as { id: string };
@@ -163,7 +180,9 @@ export default async function notesRoutes(fastify: FastifyInstance): Promise<voi
   });
 
   // ── PUT /api/folders/:id ──────────────────────────────────────────────────
-  fastify.put('/api/folders/:id', async (req: FastifyRequest, reply: FastifyReply) => {
+  fastify.put('/api/folders/:id', {
+    config: { rateLimit: { max: 120, timeWindow: '1 minute' } },
+  }, async (req: FastifyRequest, reply: FastifyReply) => {
     await verifyAuth(req, reply);
     if (reply.sent) return;
     const { id } = req.params as { id: string };


### PR DESCRIPTION
Add session metadata support and various server + frontend improvements. Database: new migration 003_session_metadata.sql adds login_ip and last_used_at; migration runner updated to include the file; user queries updated to set/return these fields and update last_used_at on refresh. Auth: capture client IP, improve User-Agent device parsing, and return currentSessionId from /api/auth/sessions. Rate limiting: global fallback increased to 500 req/min and per-route limits added/tuned for notes/auth routes in server routes and index. Frontend: Settings now shows session metadata and a "This device" badge; note editor gets many UX fixes — concurrent-save guard, robust path-based cursor preservation, toolbar selection preservation, font-size picker, color picker improvements, paste-as-plain-text handling, clear-formatting action, safe-area padding for iOS PWAs, and a server health check trigger on load. Misc: assorted UI text and style tweaks. Migration file added at server/src/db/migrations/003_session_metadata.sql.