### PR TITLE
Layout safe-area, responsive, and cache updates

### DIFF
--- a/bedroc/src/routes/+layout.svelte
+++ b/bedroc/src/routes/+layout.svelte
@@ -334,32 +334,23 @@
 <style>
 	/* ── Auth shell ───────────────────────────────────── */
 	.auth-shell {
-		min-height: 100dvh;
+		/* Use 100% of the body (position:fixed covers full physical screen with
+		   viewport-fit:cover), not 100dvh (which excludes safe area insets). */
+		min-height: 100%;
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		/* Top safe area ensures the login form isn't under the status bar.
-		   In Safari browser: safe-area-inset-top = 0, so 24px fallback applies.
-		   In PWA standalone: safe-area-inset-top = status bar height (~59px). */
 		padding-top: max(env(safe-area-inset-top, 0px), 24px);
-		padding-bottom: 24px;
+		padding-bottom: max(env(safe-area-inset-bottom, 0px), 24px);
 		padding-left: 16px;
 		padding-right: 16px;
 		background: var(--bg);
 	}
 
-	/* Standalone PWA: ensure top safe area is always applied */
-	@media (display-mode: standalone) {
-		.auth-shell {
-			padding-top: max(env(safe-area-inset-top, 44px), 44px);
-			padding-bottom: env(safe-area-inset-bottom, 24px);
-		}
-	}
-
 	/* ── App shell ────────────────────────────────────── */
 	.app-shell {
 		display: flex;
-		height: 100dvh;
+		height: 100%;
 		overflow: hidden;
 		overscroll-behavior: none;
 	}

--- a/bedroc/src/routes/+page.svelte
+++ b/bedroc/src/routes/+page.svelte
@@ -1044,7 +1044,7 @@
 
 	.drawer-chevron { flex-shrink: 0; color: var(--text-faint); }
 
-	@media (max-width: 899px) {
+	@media (max-width: 767px) {
 		.drawer-toggle { display: flex; }
 	}
 
@@ -1067,14 +1067,14 @@
 		gap: 0;
 	}
 
-	@media (min-width: 900px) {
+	@media (min-width: 768px) {
 		.topics-panel {
 			display: flex;
 		}
 		.drawer-close-btn { display: none; }
 	}
 
-	@media (max-width: 899px) {
+	@media (max-width: 767px) {
 		.topics-panel {
 			display: flex;
 			position: fixed;
@@ -1219,7 +1219,7 @@
 		flex-shrink: 0;
 		text-decoration: none;
 	}
-	@media (min-width: 900px) {
+	@media (min-width: 768px) {
 		.panel-settings-btn { display: flex; }
 	}
 	.panel-settings-btn:hover { background: var(--bg-hover); color: var(--text); text-decoration: none; }
@@ -1486,7 +1486,7 @@
 		padding: 18px 20px 0;
 	}
 
-	@media (max-width: 899px) {
+	@media (max-width: 767px) {
 		.notes-header { padding-top: 14px; }
 	}
 	@container main-pane (max-width: 699px) {

--- a/bedroc/src/routes/settings/+page.svelte
+++ b/bedroc/src/routes/settings/+page.svelte
@@ -635,7 +635,7 @@
 		background: var(--bg-elevated);
 	}
 
-	@media (min-width: 900px) {
+	@media (min-width: 768px) {
 		.topics-panel { display: flex; }
 	}
 

--- a/bedroc/static/sw.js
+++ b/bedroc/static/sw.js
@@ -25,8 +25,8 @@
  *     by the online event in the main thread instead.
  */
 
-const CACHE_NAME = 'bedroc-v4';
-const SHELL_CACHE = 'bedroc-shell-v4';
+const CACHE_NAME = 'bedroc-v5';
+const SHELL_CACHE = 'bedroc-shell-v5';
 
 // Files to pre-cache on install. SvelteKit hashes JS/CSS filenames so we
 // can't hardcode them — instead we cache the shell on first navigation fetch.


### PR DESCRIPTION
Use full-body sizing and safer safe-area insets: replace 100dvh with 100% for auth/app shells, apply max(env(...), fallback) for top/bottom paddings and remove the standalone media override. Standardize responsive breakpoints from 900px -> 768px in UI panels. Bump service worker cache names from v4 to v5 to force a new shell cache on deploy.