### PR TITLE
fix topics/folders disappearing on accidental drag,  folder row now s…

### DIFF
--- a/DEV-GUIDE.md
+++ b/DEV-GUIDE.md
@@ -313,7 +313,7 @@ Bedroc uses a **"public frontend, self-hosted backend"** model:
 
 - The frontend (this repo's `bedroc/` directory) is stateless — it has no server-side component.
 - It can be hosted anywhere: Vercel, GitHub Pages, nginx, Electron, etc.
-- At login/register, the user specifies their backend URL (defaults to `https://api.bedroc.app`).
+- At login/register, the user specifies their backend URL (defaults to `https://bedrocapi.cagancalidag.com`).
 - The backend URL is saved to localStorage so users don't re-enter it.
 
 This means:
@@ -352,8 +352,9 @@ A service worker (`bedroc/static/sw.js`) caches the app shell for true offline u
 
 ### Safari / iOS PWA notes
 
-- `viewport-fit=cover` + `env(safe-area-inset-*)` handles status-bar / home-indicator padding.
-- `body { position: fixed; background: var(--bg-elevated); padding-bottom: env(safe-area-inset-bottom) }` fills the gap below the bottom nav in PWA standalone mode.
+- **Do NOT use `viewport-fit=cover`** in the viewport meta tag. It causes iOS standalone PWA to missize the viewport, creating a persistent gap at the bottom of the screen that is invisible in Safari or DevTools emulators but visible on real devices. Without it, iOS handles safe areas natively and the viewport fills the screen properly.
+- `apple-mobile-web-app-capable: yes` + `apple-mobile-web-app-status-bar-style: black-translucent` is sufficient for full-screen standalone behaviour.
+- Safe area insets (`env(safe-area-inset-*)`) still work without `viewport-fit=cover` — use `max(env(safe-area-inset-bottom, 0px), Xpx)` fallback patterns where needed.
 - **Safari ITP cookie fix**: `restoreSession()` checks IndexedDB key material even when `tryRefreshToken()` returns `'expired'` (Safari ITP blocks cross-site httpOnly cookies). If key material exists the user sees the unlock prompt instead of a blank login form.
 
 ---
@@ -489,6 +490,41 @@ Requires native toolchain for each platform — cross-compilation is not support
 
 `main.js` handles the `context-menu` event on `mainWindow.webContents`. The menu includes Cut, Copy, Paste, Paste without formatting, and Select All — shown contextually based on whether text is selected and whether the target is editable.
 
+### Content Security Policy
+
+`main.js` sets a CSP header for every response from the local HTTP server:
+
+```text
+frame-src 'self' blob:;
+```
+
+`'self'` is required for the split-pane iframe feature (which loads `http://localhost:<port>`). `blob:` is required for PDF preview. **Do not remove `'self'`** — the split pane will show a blank panel with no error visible in the app.
+
+---
+
+## Touch / pointer input
+
+### Hover styles
+
+All CSS `:hover` rules in the app are wrapped in `@media (hover: hover)` so they only activate on real cursor devices (mouse, trackpad, Magic Keyboard). This prevents "sticky hover" on touch devices where:
+
+- Topics/folders/notes remain highlighted after a finger lifts
+- Toolbar buttons stay highlighted after a tap
+- Topics require two taps to select (first tap activates hover, second tap fires click)
+
+Any new hover rules **must** be wrapped in `@media (hover: hover)`. Do not add bare `:hover` rules — they will break touch UX.
+
+### Drag and drop (touch)
+
+Long-press (400ms) activates drag mode with haptic feedback (`navigator.vibrate(30)`). `onTouchMove` uses `document.elementFromPoint()` for hit-testing.
+
+**Critical**: always guard against self-drops:
+
+- `onTouchEnd` checks `dragId === dropTarget` and skips the action
+- `moveFolder()` checks for circular parent references before committing — a folder cannot be moved into itself or any of its descendants
+
+If a folder is accidentally given a circular `parentId` (e.g. by a bug), it becomes invisible in the sidebar (which only renders from `parentId === null`). `loadFromDb()` runs an orphan repair pass on startup: any folder with a circular or missing parentId is reset to `parentId: null`.
+
 ---
 
 ## Editor enhancements
@@ -523,6 +559,17 @@ The text color picker includes a "default" swatch (shown as a slash-circle icon,
 ### Image alignment
 
 Images support three placement modes: **inline** (default flow), **float left**, and **float right**. Mode is stored as a `data-align` attribute on the `<img>` tag and read back via `parseHTML` in the TipTap extension. A resize handle persists width as `data-width`. Both attributes survive save/reload because they use `parseHTML` + `renderHTML` (not inline styles, which TipTap does not parse back by default).
+
+### Link tooltip
+
+A tooltip appears below a link when:
+
+- The text cursor is positioned inside a link mark (`onSelectionUpdate` detects this via `marks().find(m => m.type.name === 'link')`) — works on all platforms including mobile
+- The mouse hovers over a link for 600ms (desktop/Electron only, via `mouseover` listener on the editor element)
+
+The tooltip is `position: absolute` inside `.editor-scroll-area` (which has `position: relative`). This means it scrolls with the content — `showLinkTooltip()` converts viewport coordinates from `coordsAtPos()` to scroll-area-relative coordinates using `getBoundingClientRect()` and `scrollTop`. **Do not change it to `position: fixed`** — it will then stay fixed on screen while the user scrolls, detaching from the link.
+
+Visibility logic uses three flags (`_cursorInLink`, `_mouseOnLink`, `_mouseOnTooltip`) to prevent the tooltip from disappearing while the user moves the cursor from the link to the tooltip. `scheduleLinkTooltipHide()` checks all three flags before fading out.
 
 ### Trailing paragraph
 

--- a/MANAGEMENT-GUIDE.md
+++ b/MANAGEMENT-GUIDE.md
@@ -1,6 +1,6 @@
 # Bedroc — Management Guide
 
-This guide covers day-to-day operations: viewing and editing database records, creating backups, rotating secrets, and administrative tasks. It applies to both public backend operators (running `api.bedroc.app` or similar) and private self-hosters.
+This guide covers day-to-day operations: viewing and editing database records, creating backups, rotating secrets, and administrative tasks. It applies to both public backend operators (running `bedrocapi.cagancalidag.com` or similar) and private self-hosters.
 
 ---
 

--- a/VPS-DEPLOY.md
+++ b/VPS-DEPLOY.md
@@ -231,7 +231,7 @@ curl https://api.yourdomain.com/health
 ## Step 5 — Connect from the app
 
 1. Open `https://bedroc.cagancalidag.com`
-2. Tap **Server: api.bedroc.app ▾** to expand the server URL field
+2. Tap **Server: bedrocapi.cagancalidag.com ▾** to expand the server URL field
 3. Enter `https://api.yourdomain.com`
 4. Register and start using Bedroc
 

--- a/bedroc/src/lib/stores/auth.svelte.ts
+++ b/bedroc/src/lib/stores/auth.svelte.ts
@@ -47,7 +47,7 @@ import {
 // Constants
 // ---------------------------------------------------------------------------
 
-const DEFAULT_SERVER = 'https://api.bedroc.app';
+const DEFAULT_SERVER = 'https://bedrocapi.cagancalidag.com';
 const LS_SERVERS_KEY = 'bedroc_servers';      // saved server list
 const LS_LAST_SERVER_KEY = 'bedroc_last_srv'; // most recently used server URL
 const REQUEST_TIMEOUT_MS = 12_000;            // 12s before treating as unreachable

--- a/bedroc/src/lib/stores/notes.svelte.ts
+++ b/bedroc/src/lib/stores/notes.svelte.ts
@@ -263,6 +263,30 @@ export async function loadFromDb(): Promise<void> {
   for (const f of folders) {
     foldersMap.set(f.id, localToFolder(f));
   }
+
+  // Repair orphaned folders (circular parentId references)
+  for (const [id, folder] of foldersMap) {
+    if (folder.parentId === null) continue;
+    // Walk the parent chain; if we revisit this folder's id, it's circular
+    const visited = new Set<string>([id]);
+    let cur = folder.parentId;
+    let broken = false;
+    while (cur) {
+      if (visited.has(cur)) { broken = true; break; }
+      visited.add(cur);
+      const parent = foldersMap.get(cur);
+      cur = parent?.parentId ?? null;
+    }
+    // Also broken if parentId references a folder that doesn't exist
+    if (!broken && folder.parentId && !foldersMap.has(folder.parentId)) broken = true;
+    if (broken) {
+      const fixed = { ...folder, parentId: null };
+      foldersMap.set(id, fixed);
+      // Persist the fix
+      saveFolder(fixed);
+    }
+  }
+
   for (const c of conflicts) {
     conflictsMap.set(c.noteId, c);
   }
@@ -916,6 +940,17 @@ export async function deleteFolder(id: string): Promise<void> {
 export async function moveFolder(id: string, newParentId: string | null, afterId?: string): Promise<void> {
   const folder = foldersMap.get(id);
   if (!folder) return;
+  // Prevent circular reference: can't move folder into itself or any of its descendants
+  if (newParentId !== null) {
+    if (newParentId === id) return;
+    let cur = newParentId;
+    while (cur) {
+      const p = foldersMap.get(cur);
+      if (!p || !p.parentId) break;
+      if (p.parentId === id) return; // descendant — would create cycle
+      cur = p.parentId;
+    }
+  }
   const siblings = getFolders()
     .filter((f) => f.parentId === newParentId && f.id !== id)
     .sort((a, b) => a.order - b.order);

--- a/bedroc/src/routes/+page.svelte
+++ b/bedroc/src/routes/+page.svelte
@@ -290,7 +290,7 @@
 				if (dragKind === 'note') {
 					const note = notesMap.get(dragId);
 					if (note) saveNote({ ...note, topicId: dropTarget });
-				} else if (dragKind === 'topic') {
+				} else if (dragKind === 'topic' && dragId !== dropTarget) {
 					// reorder/move topic
 					const tgt = topicsMap.get(dropTarget);
 					if (tgt) {
@@ -305,7 +305,8 @@
 					}
 				}
 			} else if (dropZone === 'folder') {
-				if (dragKind === 'topic') {
+				if (dragId === dropTarget) { /* dropped on self — no-op */ }
+				else if (dragKind === 'topic') {
 					if (dropSide === 'into') moveTopic(dragId, dropTarget);
 					else {
 						const tgt = foldersMap.get(dropTarget);
@@ -837,7 +838,9 @@
 {#snippet folderRow(folder: Folder, depth: number)}
 	<div
 		class="folder-row"
-		class:drop-target-folder={dropTarget === folder.id && dropZone === 'folder' && (dragKind === 'topic' || dragKind === 'folder')}
+		class:drop-target-folder={dropTarget === folder.id && dropZone === 'folder' && dropSide === 'into' && (dragKind === 'topic' || dragKind === 'folder')}
+		class:drop-target-folder-before={dropTarget === folder.id && dropZone === 'folder' && dropSide === 'before' && (dragKind === 'topic' || dragKind === 'folder')}
+		class:drop-target-folder-after={dropTarget === folder.id && dropZone === 'folder' && dropSide === 'after' && (dragKind === 'topic' || dragKind === 'folder')}
 	>
 		<div
 			class="folder-item"
@@ -1299,13 +1302,17 @@
 		transition: background 0.1s ease;
 	}
 
-	/* Folder: dragging a topic/note INTO this folder — full accent outline on header row */
+	/* Folder: dragging a topic/folder INTO this folder — full accent outline on header row */
 	.folder-row.drop-target-folder > .folder-item {
 		background: color-mix(in srgb, var(--accent) 12%, transparent);
 		border-radius: var(--radius-sm);
 		outline: 1.5px solid var(--accent);
 		outline-offset: -1px;
 	}
+
+	/* Folder reorder: insertion lines show where folder will land */
+	.folder-row.drop-target-folder-before { border-top: 2px solid var(--accent); }
+	.folder-row.drop-target-folder-after { border-bottom: 2px solid var(--accent); }
 
 	.folder-item {
 		display: flex;

--- a/bedroc/src/routes/login/+page.svelte
+++ b/bedroc/src/routes/login/+page.svelte
@@ -268,7 +268,7 @@
 								<button type="button" class="saved-server-btn" onclick={() => selectServer(url)}>
 									{url}
 								</button>
-								{#if url !== 'https://api.bedroc.app'}
+								{#if url !== 'https://bedrocapi.cagancalidag.com'}
 									<button
 										type="button"
 										class="btn-icon remove-server"

--- a/docs/frontend-shell.md
+++ b/docs/frontend-shell.md
@@ -238,7 +238,7 @@ No two notes in the same topic (or both uncategorised) may share the same title.
 
 - Username and password fields.
 - Password show/hide toggle.
-- Server URL row: collapsed by default showing the current URL. Expands on click to a text input with a Save button. Defaults to `https://api.bedroc.app`. Saved to `localStorage` under the key `bedroc_server`.
+- Server URL row: collapsed by default showing the current URL. Expands on click to a text input with a Save button. Defaults to `https://bedrocapi.cagancalidag.com`. Saved to `localStorage` under the key `bedroc_server`.
 - Form submission is a no-op placeholder — wired to auth logic in Phase 1.
 
 ### `/register` — Register ([register/+page.svelte](../bedroc/src/routes/register/+page.svelte))

--- a/plans/INITIAL-PLAN.md
+++ b/plans/INITIAL-PLAN.md
@@ -124,13 +124,13 @@ Bedroc/                              ← root git repo
 
 The frontend build is **always the same** regardless of where it is accessed from (website, PWA on home screen, Electron app). There are no "modes."
 
-At login and register, a subtle **server URL field** defaults to `https://api.bedroc.app` (the public hosted instance). Users change this to their own server URL to use a self-hosted backend. The chosen URL is saved to localStorage and multiple saved servers are remembered (dropdown switcher).
+At login and register, a subtle **server URL field** defaults to `https://bedrocapi.cagancalidag.com` (the public hosted instance). Users change this to their own server URL to use a self-hosted backend. The chosen URL is saved to localStorage and multiple saved servers are remembered (dropdown switcher).
 
 This transparently covers all use cases:
 
 | Use case | Server URL |
 | --- | --- |
-| Public / commercial (bedroc.app) | `https://api.bedroc.app` (default) |
+| Public / commercial (bedroc.app) | `https://bedrocapi.cagancalidag.com` (default) |
 | Self-hosted on VPS / public domain | `https://notes.mydomain.com` |
 | Self-hosted behind VPN / CGNAT | `https://100.x.x.x` (Tailscale) or `http://192.168.x.x:3000` |
 

--- a/plans/claude-plans.md
+++ b/plans/claude-plans.md
@@ -47,14 +47,14 @@ The `self-hosting/` folder that was created is superseded by this structure — 
 There are no "modes" — there is one field: **server URL**.
 
 - The frontend build is identical regardless of how it is accessed (website, PWA on home screen, Electron app).
-- Login and register screens have a subtle **server URL field** defaulting to `https://api.bedroc.app`.
+- Login and register screens have a subtle **server URL field** defaulting to `https://bedrocapi.cagancalidag.com`.
 - Users change it to their own server URL to use a self-hosted backend. The URL is saved to localStorage. Multiple saved servers are remembered (Bitwarden-style switcher).
 - This transparently covers all three use cases:
   1. **Public/commercial** — leave default URL, create account on bedroc.app
   2. **Self-hosted on VPS/public IP** — enter `https://notes.mydomain.com`
   3. **Self-hosted behind VPN/CGNAT** — enter Tailscale IP `https://100.x.x.x` or LAN `http://192.168.x.x:3000`
 - Frontend URL is irrelevant — it is either a website the user visited and added to home screen, or the Electron app.
-- The server URL field is subtle: small text "Server: api.bedroc.app ▾" that expands on tap/click to a text input + saved server dropdown.
+- The server URL field is subtle: small text "Server: bedrocapi.cagancalidag.com ▾" that expands on tap/click to a text input + saved server dropdown.
 
 ---
 

--- a/server/src/plugins/accessLog.ts
+++ b/server/src/plugins/accessLog.ts
@@ -2,7 +2,7 @@
  * plugins/accessLog.ts — Server-side access log for public deployments.
  *
  * Only active when ENABLE_ACCESS_LOG=true is set in the environment.
- * Intended for the public VPS deployment (api.bedroc.app) where the server
+ * Intended for the public VPS deployment (bedrocapi.cagancalidag.com) where the server
  * owner wants an audit trail of which IPs are logging in and when.
  *
  * NOT enabled by default — WireGuard/private self-hosted deployments have no


### PR DESCRIPTION
…hows three distinct visual states when dragging a folder or topic over it

Root cause
Long-pressing a folder on mobile activates drag mode. If your finger was still on the same folder when you released, the touch handler treated it as "drop folder onto itself" — calling moveFolder(id, id), which set the folder's parentId to its own id. This created a circular reference: the folder became its own parent. Since the sidebar renders starting from parentId === null, the folder (and everything inside it) became invisible. The data was intact — just unreachable in the UI.

Fixes
notes.svelte.ts — moveFolder() guard: Added circular reference detection. Before moving, it walks the parent chain of the target to ensure the dragged folder isn't an ancestor. Blocks self-parent and any descendant-as-parent scenarios.

+page.svelte — onTouchEnd guards: Added dragId === dropTarget checks for both folder and topic drops in the touch handler, matching the guards that already existed in the PC drag-and-drop path.

notes.svelte.ts — Orphan repair on load: After loading folders from IndexedDB, walks each folder's parent chain to detect cycles or references to non-existent folders. Any broken folder gets parentId reset to null (moved to root) and persisted. This will automatically restore your disappeared folder on next load.

2-

dropSide === 'into' — accent outline around the folder (existing style, now only when actually dropping INTO) dropSide === 'before' — blue insertion line above the folder dropSide === 'after' — blue insertion line below the folder This matches the existing topic reorder behavior. The thresholds for before/into/after are already computed in onTouchMove and onFolderDragOver (top 30% = before, middle 40% = into, bottom 30% = after), so the visual feedback now accurately reflects where the drop will land on all devices.