### PR TITLE
Add DB loaded state and loading UI

### DIFF
--- a/bedroc/src/lib/stores/notes.svelte.ts
+++ b/bedroc/src/lib/stores/notes.svelte.ts
@@ -96,6 +96,9 @@ export const foldersMap = new SvelteMap<string, Folder>();
 let _syncing = $state(false);
 export const syncState = { get syncing() { return _syncing; } };
 
+let _dbLoaded = $state(false);
+export const dbState = { get loaded() { return _dbLoaded; } };
+
 // ---------------------------------------------------------------------------
 // Conflicts reactive map
 // ---------------------------------------------------------------------------
@@ -242,6 +245,7 @@ export async function loadFromDb(): Promise<void> {
   const userId = auth.userId;
   if (!userId) return;
 
+  _dbLoaded = false;
   const [notes, topics, folders, conflicts] = await Promise.all([
     getNotesByUser(userId),
     getTopicsByUser(userId),
@@ -288,13 +292,16 @@ export async function loadFromDb(): Promise<void> {
   }
 
   for (const c of conflicts) {
-    conflictsMap.set(c.noteId, c);
-  }
+      conflictsMap.set(c.noteId, c);
+    }
+
+    _dbLoaded = true;
 }
 
 /** Clear reactive maps on logout. */
 export function clearStore(): void {
-  notesMap.clear();
+    _dbLoaded = false;
+    notesMap.clear();
   topicsMap.clear();
   foldersMap.clear();
   conflictsMap.clear();

--- a/bedroc/src/routes/+layout.svelte
+++ b/bedroc/src/routes/+layout.svelte
@@ -6,7 +6,7 @@
 	import { auth, restoreSession, serverStatus, lockVault } from '$lib/stores/auth.svelte.js';
 	import { initTheme } from '$lib/stores/theme.svelte.js';
 	import { connect as wsConnect, disconnect as wsDisconnect } from '$lib/sync/websocket.js';
-	import { syncFromServer, syncIntervalStore, loadFromDb, inactivityLockStore } from '$lib/stores/notes.svelte.js';
+import { syncFromServer, syncIntervalStore, loadFromDb, inactivityLockStore, dbState } from '$lib/stores/notes.svelte.js';
 
 	let { children } = $props();
 
@@ -212,13 +212,19 @@
 </script>
 
 {#if !authInitialized && !isAuthRoute}
-	<div class="app-shell" style="display:flex;align-items:center;justify-content:center;color:var(--text-faint)">
-		<!-- Optional: A subtle loading indicator could go here -->
-	</div>
+        <div class="app-shell" style="display:flex;align-items:center;justify-content:center;color:var(--text-faint)">
+        </div>
 {:else if isAuthRoute}
-	<div class="auth-shell">
-		{@render children()}
-	</div>
+        <div class="auth-shell">
+                {@render children()}
+        </div>
+{:else if !dbState.loaded}
+        <div class="app-shell" style="display:flex;flex-direction:column;gap:1.5rem;align-items:center;justify-content:center;color:var(--text-faint);height:100vh;">
+                <svg width="36" height="36" viewBox="0 0 24 24" fill="none" class="animate-spin" style="color:var(--accent);" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+                        <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/>
+                </svg>
+                <div style="font-size:0.9rem;opacity:0.8;">Loading vault...</div>
+        </div>
 {:else}
 	<div class="app-shell">
 		<!-- ── Main content area ────────────────────────── -->


### PR DESCRIPTION
Introduce a reactive dbState.loaded flag in notes.svelte.ts (_dbLoaded) that is set false before DB fetch, set true after loading conflicts, and reset on clearStore. Update +layout.svelte to import dbState and show a simple "Loading vault..." spinner screen when the DB hasn't finished loading. Also includes minor indentation/formatting tweaks in the layout.