### PR TITLE
Add initial loading spinner and initial-sync state

### DIFF
--- a/bedroc/src/app.html
+++ b/bedroc/src/app.html
@@ -57,6 +57,17 @@
 		</script>
 	</head>
 	<body data-sveltekit-preload-data="hover">
-		<div style="display: contents">%sveltekit.body%</div>
+		<div id="initial-bedroc-spinner" style="position:fixed;inset:0;display:flex;flex-direction:column;gap:1.5rem;align-items:center;justify-content:center;color:#4a4d5e;background-color:#16181f;z-index:999999;">
+            <style>
+                @keyframes bedroc-spin { to { transform: rotate(360deg); } }
+                #initial-bedroc-spinner svg { animation: bedroc-spin 1s linear infinite; color: #6b8afd; }
+                html[data-theme="light"] #initial-bedroc-spinner { background-color: #ffffff; color: #7f85a5; }
+                html[data-theme="light"] #initial-bedroc-spinner svg { color: #5a7af0; }
+            </style>
+            <svg width="36" height="36" viewBox="0 0 24 24" fill="none" class="app-spinner" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+                <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/>
+            </svg>
+        </div>
+        <div style="display: contents">%sveltekit.body%</div>
 	</body>
 </html>

--- a/bedroc/src/lib/stores/notes.svelte.ts
+++ b/bedroc/src/lib/stores/notes.svelte.ts
@@ -94,7 +94,10 @@ export const topicsMap = new SvelteMap<string, Topic>();
 export const foldersMap = new SvelteMap<string, Folder>();
 
 let _syncing = $state(false);
-export const syncState = { get syncing() { return _syncing; } };
+export const syncState = {
+  get syncing() { return _syncing; },
+  get isInitialSync() { return _syncing && (typeof localStorage === 'undefined' || localStorage.getItem(lastSyncKey()) === null); }
+};
 
 let _dbLoaded = $state(false);
 export const dbState = { get loaded() { return _dbLoaded; } };

--- a/bedroc/src/routes/+layout.svelte
+++ b/bedroc/src/routes/+layout.svelte
@@ -6,7 +6,7 @@
 	import { auth, restoreSession, serverStatus, lockVault } from '$lib/stores/auth.svelte.js';
 	import { initTheme } from '$lib/stores/theme.svelte.js';
 	import { connect as wsConnect, disconnect as wsDisconnect } from '$lib/sync/websocket.js';
-import { syncFromServer, syncIntervalStore, loadFromDb, inactivityLockStore, dbState } from '$lib/stores/notes.svelte.js';
+	import { syncFromServer, syncIntervalStore, loadFromDb, inactivityLockStore, dbState, syncState } from '$lib/stores/notes.svelte.js';
 
 	let { children } = $props();
 
@@ -41,6 +41,7 @@ import { syncFromServer, syncIntervalStore, loadFromDb, inactivityLockStore, dbS
 	// If that fails (or DEK is missing), redirect to /login.
 	// On success, open the WebSocket connection for real-time sync.
 	onMount(async () => {
+		document.getElementById('initial-bedroc-spinner')?.remove();
 		isInIframe = window.self !== window.top;
 		if (isAuthRoute) { authInitialized = true; return; }
 		// Skip restoreSession if already logged in (e.g. just came from login page).
@@ -212,18 +213,22 @@ import { syncFromServer, syncIntervalStore, loadFromDb, inactivityLockStore, dbS
 </script>
 
 {#if !authInitialized && !isAuthRoute}
-        <div class="app-shell" style="display:flex;align-items:center;justify-content:center;color:var(--text-faint)">
+        <div class="app-shell" style="display:flex;flex-direction:column;gap:1.5rem;align-items:center;justify-content:center;color:var(--text-faint);height:100vh;">
+                <svg width="36" height="36" viewBox="0 0 24 24" fill="none" class="animate-spin" style="color:var(--accent);" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+					<path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/>
+                </svg>
+                <div style="font-size:0.9rem;opacity:0.8;">Loading...</div>
         </div>
 {:else if isAuthRoute}
         <div class="auth-shell">
                 {@render children()}
         </div>
-{:else if !dbState.loaded}
+{:else if !dbState.loaded || syncState.isInitialSync}
         <div class="app-shell" style="display:flex;flex-direction:column;gap:1.5rem;align-items:center;justify-content:center;color:var(--text-faint);height:100vh;">
-                <svg width="36" height="36" viewBox="0 0 24 24" fill="none" class="animate-spin" style="color:var(--accent);" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-                        <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/>
-                </svg>
-                <div style="font-size:0.9rem;opacity:0.8;">Loading vault...</div>
+			<svg width="36" height="36" viewBox="0 0 24 24" fill="none" class="animate-spin" style="color:var(--accent);" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+				<path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/>
+			</svg>
+			<div style="font-size:0.9rem;opacity:0.8;">Loading vault...</div>
         </div>
 {:else}
 	<div class="app-shell">


### PR DESCRIPTION
Insert a full-page initial spinner in app.html (with theme-aware styles and animation) to show while the app boots. Expose syncState.isInitialSync in notes store (checks localStorage via lastSyncKey) so the UI can detect a first-time sync. Update +layout.svelte to import syncState, remove the DOM spinner on mount, and keep showing the app loading screen until DB is loaded or the initial sync completes; also tweak loading UI markup and styles for consistency.