### PR TITLE
Defer scroll update on pinch; update SW cache

### DIFF
--- a/bedroc/src/routes/note/[id]/+page.svelte
+++ b/bedroc/src/routes/note/[id]/+page.svelte
@@ -379,8 +379,16 @@
 			const ratio = _getPinchDist(e.touches) / _pinchStartDist;
 			const newScale = Number(Math.max(_printMinScale, Math.min(3, _pinchStartScale * ratio)).toFixed(4));
 			mobilePrintScale = newScale;
-			scrollAreaEl.scrollLeft = Math.max(0, _pinchFocalX * newScale - _pinchVP_X);
-			scrollAreaEl.scrollTop  = Math.max(0, _pinchFocalY * newScale - _pinchVP_Y);
+			// Defer scroll position update — Svelte needs one frame to re-render
+			// the print-scale-outer dimensions before scrollLeft/scrollTop can be set.
+			const tLeft = Math.max(0, _pinchFocalX * newScale - _pinchVP_X);
+			const tTop  = Math.max(0, _pinchFocalY * newScale - _pinchVP_Y);
+			requestAnimationFrame(() => {
+				if (scrollAreaEl) {
+					scrollAreaEl.scrollLeft = tLeft;
+					scrollAreaEl.scrollTop  = tTop;
+				}
+			});
 		} else if (e.touches.length === 1 && !_isPinching) {
 			const dx = _scrollTouchStartX - e.touches[0].clientX;
 			const dy = _scrollTouchStartY - e.touches[0].clientY;
@@ -430,8 +438,14 @@
 		const gestureScale = e.detail?.scale ?? 1;
 		const newScale = Number(Math.max(_printMinScale, Math.min(3, _pinchStartScale * gestureScale)).toFixed(4));
 		mobilePrintScale = newScale;
-		scrollAreaEl.scrollLeft = Math.max(0, _pinchFocalX * newScale - _pinchVP_X);
-		scrollAreaEl.scrollTop  = Math.max(0, _pinchFocalY * newScale - _pinchVP_Y);
+		const tLeft = Math.max(0, _pinchFocalX * newScale - _pinchVP_X);
+		const tTop  = Math.max(0, _pinchFocalY * newScale - _pinchVP_Y);
+		requestAnimationFrame(() => {
+			if (scrollAreaEl) {
+				scrollAreaEl.scrollLeft = tLeft;
+				scrollAreaEl.scrollTop  = tTop;
+			}
+		});
 	}
 
 	// Remove all injected spacers from ProseMirror DOM

--- a/bedroc/static/sw.js
+++ b/bedroc/static/sw.js
@@ -25,8 +25,8 @@
  *     by the online event in the main thread instead.
  */
 
-const CACHE_NAME = 'bedroc-v1.0.11';
-const SHELL_CACHE = 'bedroc-shell-v1.0.11';
+const CACHE_NAME = 'bedroc-v1.0.12';
+const SHELL_CACHE = 'bedroc-shell-v1.0.12';
 
 // Files to pre-cache on install. SvelteKit hashes JS/CSS filenames so we
 // can't hardcode them — instead we cache the shell on first navigation fetch.


### PR DESCRIPTION
When handling pinch/gesture zoom on the note page, defer setting scrollLeft/scrollTop via requestAnimationFrame (and guard against a missing scrollAreaEl) so Svelte has a frame to re-render the scaled container before scrolling. Also bump service worker cache names from v1.0.11 to v1.0.12.