### PR TITLE
Add app version/commit, privacy & terms pages

### DIFF
--- a/bedroc/package.json
+++ b/bedroc/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "bedroc",
 	"private": true,
-	"version": "1.0.13",
+	"version": "1.0.14",
 	"type": "module",
 	"author": "Cagan Calidag <contact@cagancalidag.com>",
 	"scripts": {

--- a/bedroc/src/global.d.ts
+++ b/bedroc/src/global.d.ts
@@ -1,0 +1,2 @@
+declare const __APP_VERSION__: string;
+declare const __COMMIT_HASH__: string;

--- a/bedroc/src/routes/login/+page.svelte
+++ b/bedroc/src/routes/login/+page.svelte
@@ -328,6 +328,16 @@
 			No account? <a href="/register">Register</a>
 		</p>
 	{/if}
+
+	<div class="auth-footer">
+		<span>v{__APP_VERSION__} <code>{__COMMIT_HASH__}</code></span>
+		<span class="dot-sep">·</span>
+		<a href="/privacy.html" target="_blank" rel="noopener">Privacy</a>
+		<span class="dot-sep">·</span>
+		<a href="/terms.html" target="_blank" rel="noopener">Terms</a>
+		<span class="dot-sep">·</span>
+		<a href="mailto:contact@cagancalidag.com">Contact</a>
+	</div>
 </div>
 
 <style>
@@ -588,6 +598,27 @@
 		font-size: 13px;
 		color: var(--text-muted);
 	}
+
+	.auth-footer {
+		text-align: center;
+		font-size: 10px;
+		color: var(--text-faint);
+		margin-top: 4px;
+	}
+	.auth-footer code {
+		font-family: ui-monospace, monospace;
+		background: var(--bg-hover);
+		padding: 1px 4px;
+		border-radius: 3px;
+	}
+	.auth-footer a {
+		color: var(--text-faint);
+		text-decoration: none;
+	}
+	@media (hover: hover) {
+		.auth-footer a:hover { color: var(--accent); }
+	}
+	.dot-sep { margin: 0 4px; }
 
 	/* ── Corner 3-dot menu ──────────────────────────────── */
 	/* The .auth-shell (in layout) uses position:relative so we can fix

--- a/bedroc/src/routes/register/+page.svelte
+++ b/bedroc/src/routes/register/+page.svelte
@@ -307,6 +307,16 @@
 	<p class="auth-switch">
 		Already have an account? <a href="/login">Log in</a>
 	</p>
+
+	<div class="auth-footer">
+		<span>v{__APP_VERSION__} <code>{__COMMIT_HASH__}</code></span>
+		<span class="dot-sep">·</span>
+		<a href="/privacy.html" target="_blank" rel="noopener">Privacy</a>
+		<span class="dot-sep">·</span>
+		<a href="/terms.html" target="_blank" rel="noopener">Terms</a>
+		<span class="dot-sep">·</span>
+		<a href="mailto:contact@cagancalidag.com">Contact</a>
+	</div>
 </div>
 
 <style>
@@ -594,4 +604,25 @@
 	@media (hover: hover) { .corner-menu-danger:hover { background: color-mix(in srgb, var(--danger) 10%, transparent); } }
 	.corner-menu-confirm-text { font-size: 12px; color: var(--text-muted); padding: 8px 10px 4px; line-height: 1.5; }
 	.corner-menu-confirm-btns { display: flex; gap: 4px; padding: 4px; }
+
+	.auth-footer {
+		text-align: center;
+		font-size: 10px;
+		color: var(--text-faint);
+		margin-top: 4px;
+	}
+	.auth-footer code {
+		font-family: ui-monospace, monospace;
+		background: var(--bg-hover);
+		padding: 1px 4px;
+		border-radius: 3px;
+	}
+	.auth-footer a {
+		color: var(--text-faint);
+		text-decoration: none;
+	}
+	@media (hover: hover) {
+		.auth-footer a:hover { color: var(--accent); }
+	}
+	.dot-sep { margin: 0 4px; }
 </style>

--- a/bedroc/src/routes/settings/+page.svelte
+++ b/bedroc/src/routes/settings/+page.svelte
@@ -568,7 +568,17 @@
 		</div>
 	</section>
 
-	<p class="version">Bedroc v0.1.0 — open source, E2EE</p>
+	<div class="version-block">
+		<p class="version">Bedroc v{__APP_VERSION__} — open source, E2EE</p>
+		<p class="version commit">commit <code>{__COMMIT_HASH__}</code></p>
+		<p class="version links">
+			<a href="/privacy.html" target="_blank" rel="noopener">Privacy Policy</a>
+			<span class="dot-sep">·</span>
+			<a href="/terms.html" target="_blank" rel="noopener">Terms of Service</a>
+			<span class="dot-sep">·</span>
+			<a href="mailto:contact@cagancalidag.com">Contact</a>
+		</p>
+	</div>
 </div><!-- end .page -->
 </div><!-- end .settings-layout -->
 
@@ -1049,11 +1059,36 @@
 	}
 
 	/* Version */
+	.version-block {
+		text-align: center;
+		padding-top: 8px;
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
 	.version {
 		font-size: 11px;
 		color: var(--text-faint);
-		text-align: center;
-		padding-top: 8px;
+	}
+	.version.commit code {
+		font-family: ui-monospace, monospace;
+		font-size: 10px;
+		background: var(--bg-hover);
+		padding: 1px 4px;
+		border-radius: 3px;
+	}
+	.version.links a {
+		color: var(--text-faint);
+		text-decoration: none;
+		font-size: 11px;
+	}
+	@media (hover: hover) {
+		.version.links a:hover { color: var(--accent); }
+	}
+	.dot-sep {
+		color: var(--text-faint);
+		margin: 0 4px;
+		font-size: 11px;
 	}
 
 	/* Change password form */

--- a/bedroc/static/privacy.html
+++ b/bedroc/static/privacy.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<meta name="robots" content="noindex"/>
+<title>Privacy Policy — Bedroc</title>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI','Helvetica Neue',Arial,sans-serif;background:#16181f;color:#e2e4ed;padding:40px 20px 80px;line-height:1.6}
+.content{max-width:680px;margin:0 auto}
+.back{display:inline-block;font-size:13px;color:#8b8fa8;text-decoration:none;margin-bottom:32px;background:none;border:none;padding:0;cursor:pointer;font-family:inherit}
+.back:hover{color:#6b8afd}
+h1{font-size:28px;font-weight:700;letter-spacing:-0.02em;margin-bottom:6px}
+.updated{font-size:12px;color:#4a4d5e;margin-bottom:40px}
+section{margin-bottom:36px}
+h2{font-size:15px;font-weight:600;margin-bottom:10px}
+p{font-size:14px;color:#8b8fa8;margin-bottom:10px}
+ul{margin:0 0 10px;padding-left:20px}
+li{font-size:14px;color:#8b8fa8;margin-bottom:4px}
+strong{color:#e2e4ed}
+code{font-family:ui-monospace,monospace;font-size:12px;background:#1e2028;padding:1px 5px;border-radius:3px}
+a{color:#6b8afd;text-decoration:none}
+a:hover{text-decoration:underline}
+.notice{background:#1e2028;border:1px solid #2a2d37;border-radius:8px;padding:14px 16px;font-size:13px;color:#8b8fa8;margin-bottom:10px}
+</style>
+</head>
+<body>
+<div class="content">
+<button class="back" onclick="window.close()">← Close</button>
+<h1>Privacy Policy</h1>
+<p class="updated">Last updated: April 2025</p>
+
+<section>
+<h2>Who we are</h2>
+<p>Bedroc is operated by <strong>Cagan Efe Calidag</strong>, an individual (not a registered company). Contact: <a href="mailto:contact@cagancalidag.com">contact@cagancalidag.com</a>.</p>
+<p>The frontend application is hosted at <strong>bedroc.cagancalidag.com</strong>. The default backend API is hosted at <strong>bedrocapi.cagancalidag.com</strong>. Both domains are proxied through Cloudflare.</p>
+</section>
+
+<section>
+<h2>The short version</h2>
+<div class="notice">Bedroc is end-to-end encrypted. Your notes are encrypted on your device before leaving it. We technically <strong>cannot</strong> read your notes — we never hold the keys. What we describe below is the minimal metadata we do handle.</div>
+</section>
+
+<section>
+<h2>What data we process</h2>
+<ul>
+<li><strong>Username</strong> — chosen by you, stored on the backend server in plain text to identify your account.</li>
+<li><strong>SRP verifier</strong> — a one-way cryptographic token derived from your password. Your actual password is never transmitted or stored anywhere.</li>
+<li><strong>Encrypted ciphertext</strong> — your note titles and bodies, encrypted with AES-256-GCM on your device. The server stores and syncs only ciphertext; content is never readable by the operator.</li>
+<li><strong>Timestamps</strong> — creation and last-modified timestamps, used for sync conflict resolution.</li>
+<li><strong>Session tokens</strong> — a short-lived access token (in memory only) and a refresh token stored in an <code>httpOnly</code> cookie, used to keep you logged in.</li>
+<li><strong>IP addresses</strong> — your requests pass through Cloudflare's network before reaching the server. The server receives Cloudflare's proxy IP, not your real IP address. Cloudflare may log your real IP per their own <a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener">privacy policy</a>. The Bedroc application itself does not log IP addresses.</li>
+</ul>
+<p>We do not collect analytics, telemetry, device fingerprints, advertising identifiers, or any other data beyond what is listed above.</p>
+</section>
+
+<section>
+<h2>Legal basis for processing (GDPR)</h2>
+<p>If you are located in the European Economic Area, we process your data on the following bases:</p>
+<ul>
+<li><strong>Contract performance</strong> (Art. 6(1)(b) GDPR) — processing your username, verifier, and encrypted notes is necessary to provide the sync service you sign up for.</li>
+<li><strong>Legitimate interests</strong> (Art. 6(1)(f) GDPR) — session tokens are necessary to maintain authenticated sessions securely.</li>
+</ul>
+<p>Because note content is encrypted client-side and we hold no decryption keys, we cannot identify natural persons from the ciphertext we store. This significantly limits the personal data we actually process.</p>
+</section>
+
+<section>
+<h2>Self-hosted backends</h2>
+<p>Bedroc uses a "public frontend, self-hosted backend" model. If you configure the app to use your own backend server, your encrypted data is stored entirely on your own infrastructure and this privacy policy does not govern that data. This policy applies only to data processed through the operator-provided default backend.</p>
+</section>
+
+<section>
+<h2>Encryption details</h2>
+<ul>
+<li>Master key derivation: PBKDF2-SHA256, 600,000 iterations.</li>
+<li>Note encryption: AES-256-GCM with a per-account Data Encryption Key (DEK) wrapped by your master key.</li>
+<li>Authentication: SRP-6a zero-knowledge protocol — your password never leaves your device.</li>
+<li><strong>There is no password reset.</strong> If you lose your password, your encrypted data cannot be recovered by anyone, including the operator.</li>
+</ul>
+</section>
+
+<section>
+<h2>Data retention</h2>
+<p>Your data is retained for as long as your account exists. You may permanently delete your account and all associated data at any time from the Settings page. Deletion is immediate and irreversible at the application level. However, as noted above, infrastructure-level backups held by the VPS provider (IONOS) may retain encrypted traces for a period outside the operator's control. All such residual data is encrypted ciphertext for which no decryption key is held by the operator or the provider.</p>
+</section>
+
+<section>
+<h2>Third-party services</h2>
+<ul>
+<li><strong>Cloudflare</strong> — both domains are proxied through Cloudflare for DDoS protection and TLS termination. Cloudflare may process connection metadata (IP addresses, request headers) per their privacy policy.</li>
+<li><strong>Vercel</strong> — the frontend static files are served via Vercel. Vercel may log access requests per their privacy policy. No user data is processed by Vercel as the frontend is a static SPA.</li>
+<li><strong>IONOS</strong> — the backend server runs on an IONOS VPS. As with all infrastructure providers, IONOS may take periodic snapshots or backups of the underlying host at the infrastructure level as part of their standard operations. This means that even after you delete your account and data, encrypted traces may persist in infrastructure-level backups outside the operator's control. All such data remains encrypted ciphertext — IONOS does not hold decryption keys.</li>
+</ul>
+<p>No advertising networks, analytics platforms, or tracking scripts are used.</p>
+</section>
+
+<section>
+<h2>Your rights</h2>
+<p>If you are in the EEA or UK, you have the right to access, rectify, or erase your personal data. Given the encrypted nature of the service, the most meaningful way to exercise these rights is through the app itself (export notes, delete account). For other requests, contact <a href="mailto:contact@cagancalidag.com">contact@cagancalidag.com</a>.</p>
+<p>You also have the right to lodge a complaint with a supervisory authority. If you are in France, this is the <a href="https://www.cnil.fr" target="_blank" rel="noopener">CNIL</a>.</p>
+</section>
+
+<section>
+<h2>Cookies</h2>
+<p>Bedroc uses one cookie: a <code>httpOnly; Secure; SameSite=None</code> cookie containing your refresh token, necessary for cross-origin authenticated sessions. No tracking, advertising, or analytics cookies are used.</p>
+</section>
+
+<section>
+<h2>Changes to this policy</h2>
+<p>This policy may be updated from time to time. Material changes will be indicated by updating the "Last updated" date above.</p>
+</section>
+
+<section>
+<h2>Contact</h2>
+<p>For privacy questions or data requests: <a href="mailto:contact@cagancalidag.com">contact@cagancalidag.com</a></p>
+<p>For law enforcement or legal inquiries: contact the same address. Note that due to end-to-end encryption, we are technically unable to provide note content even if compelled — we do not hold decryption keys.</p>
+</section>
+</div>
+</body>
+</html>

--- a/bedroc/static/sw.js
+++ b/bedroc/static/sw.js
@@ -25,8 +25,8 @@
  *     by the online event in the main thread instead.
  */
 
-const CACHE_NAME = 'bedroc-v1.0.13';
-const SHELL_CACHE = 'bedroc-shell-v1.0.13';
+const CACHE_NAME = 'bedroc-v1.0.14';
+const SHELL_CACHE = 'bedroc-shell-v1.0.14';
 
 // Files to pre-cache on install. SvelteKit hashes JS/CSS filenames so we
 // can't hardcode them — instead we cache the shell on first navigation fetch.

--- a/bedroc/static/terms.html
+++ b/bedroc/static/terms.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<meta name="robots" content="noindex"/>
+<title>Terms of Service — Bedroc</title>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI','Helvetica Neue',Arial,sans-serif;background:#16181f;color:#e2e4ed;padding:40px 20px 80px;line-height:1.6}
+.content{max-width:680px;margin:0 auto}
+.back{display:inline-block;font-size:13px;color:#8b8fa8;text-decoration:none;margin-bottom:32px;background:none;border:none;padding:0;cursor:pointer;font-family:inherit}
+.back:hover{color:#6b8afd}
+h1{font-size:28px;font-weight:700;letter-spacing:-0.02em;margin-bottom:6px}
+.updated{font-size:12px;color:#4a4d5e;margin-bottom:40px}
+section{margin-bottom:36px}
+h2{font-size:15px;font-weight:600;margin-bottom:10px}
+p{font-size:14px;color:#8b8fa8;margin-bottom:10px}
+ul{margin:0 0 10px;padding-left:20px}
+li{font-size:14px;color:#8b8fa8;margin-bottom:4px}
+strong{color:#e2e4ed}
+a{color:#6b8afd;text-decoration:none}
+a:hover{text-decoration:underline}
+.notice{background:#1e2028;border:1px solid #2a2d37;border-radius:8px;padding:14px 16px;font-size:13px;color:#8b8fa8;margin-bottom:10px}
+</style>
+</head>
+<body>
+<div class="content">
+<button class="back" onclick="window.close()">← Close</button>
+<h1>Terms of Service</h1>
+<p class="updated">Last updated: April 2025</p>
+
+<section>
+<h2>Operator</h2>
+<p>Bedroc is operated by <strong>Cagan Efe Calidag</strong>, an individual (not a registered company or legal entity). By using Bedroc, you enter into an agreement with this individual operator. Contact: <a href="mailto:contact@cagancalidag.com">contact@cagancalidag.com</a>.</p>
+</section>
+
+<section>
+<h2>Acceptance</h2>
+<p>By creating an account or using Bedroc, you agree to these Terms of Service and our <a href="/privacy.html">Privacy Policy</a>. If you do not agree, do not use the service.</p>
+</section>
+
+<section>
+<h2>Description of service</h2>
+<p>Bedroc is a free, end-to-end encrypted note-taking application. The source code is open source and available at <a href="https://github.com/MrBiscuitTR/Bedroc" target="_blank" rel="noopener">github.com/MrBiscuitTR/Bedroc</a>. You may self-host the backend on your own infrastructure under the terms of the project's open-source license.</p>
+</section>
+
+<section>
+<h2>Your data and encryption</h2>
+<div class="notice">All note content is encrypted on your device before reaching any server. The operator cannot read, access, or recover your notes under any circumstances.</div>
+<ul>
+<li>You own your data. You may export it at any time from the Settings page.</li>
+<li>You may permanently delete your account and all associated data at any time from the Settings page.</li>
+<li><strong>Password loss is permanent.</strong> There is no recovery mechanism. If you lose your password, your encrypted data cannot be recovered by you or the operator.</li>
+</ul>
+</section>
+
+<section>
+<h2>Acceptable use</h2>
+<p>You agree not to use Bedroc to:</p>
+<ul>
+<li>Violate any applicable laws or regulations.</li>
+<li>Store, transmit, or distribute content that is illegal in your jurisdiction or in France.</li>
+<li>Attempt to gain unauthorized access to other accounts, servers, or infrastructure.</li>
+<li>Probe, scan, or test the vulnerability of the service without explicit written permission.</li>
+<li>Abuse, overload, or interfere with the service in a way that degrades availability for other users.</li>
+<li>Use the service to facilitate spam, phishing, or distribution of malware.</li>
+</ul>
+<p>Because note content is end-to-end encrypted, the operator cannot monitor content for policy violations. You are solely responsible for ensuring your use of the service complies with applicable law.</p>
+</section>
+
+<section>
+<h2>Account termination</h2>
+<p>You may delete your account at any time. The operator reserves the right to suspend or terminate accounts that are found to be in clear violation of these terms (e.g. abuse of the service infrastructure), to the extent technically possible given the encrypted nature of the service.</p>
+</section>
+
+<section>
+<h2>Service availability</h2>
+<p>Bedroc is provided on a best-effort basis by an individual operator with no commercial backing. There are no uptime guarantees. The service may be modified, interrupted, or discontinued at any time with reasonable notice where possible.</p>
+<p>For critical use cases, you are strongly encouraged to self-host the backend and maintain your own exports.</p>
+</section>
+
+<section>
+<h2>Disclaimer of warranties</h2>
+<p>The service is provided <strong>"as is"</strong> and <strong>"as available"</strong> without any warranties of any kind, express or implied, including but not limited to warranties of merchantability, fitness for a particular purpose, or non-infringement.</p>
+</section>
+
+<section>
+<h2>Limitation of liability</h2>
+<p>To the fullest extent permitted by applicable law, the operator shall not be liable for any indirect, incidental, special, consequential, or punitive damages, including but not limited to loss of data, loss of access, or loss of profits, arising out of or related to your use of or inability to use the service.</p>
+<p>The operator's total aggregate liability to you for any claims arising from these terms or your use of the service shall not exceed the amount you have paid for the service in the twelve months preceding the claim (which, since Bedroc is free, is zero).</p>
+<p><strong>If you lose your password, your encrypted data cannot be recovered. This is a fundamental property of the encryption architecture, not a service failure.</strong></p>
+</section>
+
+<section>
+<h2>Governing law</h2>
+<p>These terms are governed by the laws of France, where the operator is currently resident, without regard to conflict of law provisions. Any disputes shall be subject to the jurisdiction of the competent courts of France, unless mandatory consumer protection law in your country of residence provides otherwise.</p>
+</section>
+
+<section>
+<h2>Changes to these terms</h2>
+<p>These terms may be updated from time to time. Material changes will be indicated by updating the "Last updated" date above. Continued use of the service after changes constitutes acceptance of the updated terms.</p>
+</section>
+
+<section>
+<h2>Contact &amp; abuse reports</h2>
+<p>For questions, abuse reports, or legal inquiries: <a href="mailto:contact@cagancalidag.com">contact@cagancalidag.com</a></p>
+<p>For law enforcement or official legal matters: contact the same address. Please note that due to end-to-end encryption, the operator is technically unable to provide note content — decryption keys are never held by the operator.</p>
+</section>
+</div>
+</body>
+</html>

--- a/bedroc/vite.config.ts
+++ b/bedroc/vite.config.ts
@@ -1,7 +1,20 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
+import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const pkg = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf-8'));
+const commitHash = (() => {
+	try { return execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim(); }
+	catch { return 'unknown'; }
+})();
 
 export default defineConfig({
-	plugins: [tailwindcss(), sveltekit()]
+	plugins: [tailwindcss(), sveltekit()],
+	define: {
+		__APP_VERSION__: JSON.stringify(pkg.version),
+		__COMMIT_HASH__: JSON.stringify(commitHash),
+	},
 });

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bedroc",
-	"version": "1.0.13",
+	"version": "1.0.14",
 	"description": "Bedroc — private, encrypted notes",
 	"homepage": "https://github.com/MrBiscuitTR/Bedroc",
 	"author": "Cagan Calidag <contact@cagancalidag.com>",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bedroc-server",
-	"version": "1.0.13",
+	"version": "1.0.14",
 	"description": "Bedroc backend — Fastify + PostgreSQL + Redis",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
Expose build-time __APP_VERSION__ and __COMMIT_HASH__ via Vite define (reads package.json and git short hash, falls back to 'unknown'), and add a global.d.ts for the constants. Surface version and commit in the UI (login, register footers and settings page) with links to Privacy/Terms and contact. Add static privacy.html and terms.html pages, update service worker cache names to match v1.0.14, and bump package versions (bedroc, desktop, server) to 1.0.14.